### PR TITLE
Feature/add i18n

### DIFF
--- a/docs/_docs/articles.md
+++ b/docs/_docs/articles.md
@@ -1,6 +1,6 @@
 ---
 title: Articles
-nav_order: 94
+nav_order: 95
 ---
 
 {% include tutorials.md %}

--- a/docs/_docs/conduct.md
+++ b/docs/_docs/conduct.md
@@ -1,6 +1,6 @@
 ---
 title: The Jets Community Conduct Guideline
-nav_order: 99
+nav_order: 100
 ---
 
 We have picked the following conduct guideline based on Ruby's.  We wish for the Jets community to be safe, productive, and collaborative. Each Jets related community may pick their own Conduct Guideline or Code.

--- a/docs/_docs/considerations.md
+++ b/docs/_docs/considerations.md
@@ -1,6 +1,6 @@
 ---
 title: Considerations
-nav_order: 91
+nav_order: 92
 ---
 
 The following sections cover some considerations, limits, and benefits. Hopefully they are helpful.

--- a/docs/_docs/considerations/api-gateway.md
+++ b/docs/_docs/considerations/api-gateway.md
@@ -1,6 +1,6 @@
 ---
 title: API Gateway Routes
-nav_order: 92
+nav_order: 93
 ---
 
 Jets translates `config/routes.rb` definitions to API Gateway Resources: [Routing Overview](http://rubyonjets.com/docs/routing/). Essentially, API Gateway is the routing layer of a Jets application.  From the [AWS API Gateway](https://aws.amazon.com/api-gateway/) product page:

--- a/docs/_docs/considerations/vpc.md
+++ b/docs/_docs/considerations/vpc.md
@@ -1,6 +1,6 @@
 ---
 title: VPC
-nav_order: 93
+nav_order: 94
 ---
 
 **Update 9/3/2019**: [Announcing improved VPC networking for AWS Lambda functions](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/). This removes the extra cold-start penalty associated with Lambda and VPC. It essentially moves the creation of the ENI to function creation time instead of invocation time.

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing to Jets
-nav_order: 97
+nav_order: 98
 ---
 
 Hi there! Interested in contributing to Jets? We'd love your help. Jets is an open source project, built one contribution at a time by users like you.

--- a/docs/_docs/extras/internationalization.md
+++ b/docs/_docs/extras/internationalization.md
@@ -1,0 +1,14 @@
+---
+title: Internationalization
+nav_order: 78
+---
+
+Jets now supports [I18n](https://github.com/ruby-i18n/i18n) internationalization functionality out of the box.
+
+Simply add it to your `Gemfile`
+
+    $ gem 'i18n'
+
+Then go about replacing text you would like to internationalize as you normally would with [I18n](https://github.com/ruby-i18n/i18n).
+
+{% include prev_next.md %}

--- a/docs/_docs/extras/internationalization.md
+++ b/docs/_docs/extras/internationalization.md
@@ -1,6 +1,6 @@
 ---
 title: Internationalization
-nav_order: 78
+nav_order: 87
 ---
 
 Jets now supports [I18n](https://github.com/ruby-i18n/i18n) internationalization functionality out of the box.

--- a/docs/_docs/lambdagems.md
+++ b/docs/_docs/lambdagems.md
@@ -1,6 +1,6 @@
 ---
 title: Lambda Gems
-nav_order: 96
+nav_order: 97
 ---
 
 Jets deploy packages up the gems used by your application as part of the zip file and deploys it to AWS Lambda.  Most gems can be used with Lambda as-is because they are pure Ruby code. However, some gems use compiled native extensions. For example, nokogiri uses compiled native extensions. This presents a problem as your machine's architecture likely does not match the AWS Lambda environment's architecture.  The same compiled gems on your machine will not work on Lambda.

--- a/docs/_docs/next-steps.md
+++ b/docs/_docs/next-steps.md
@@ -1,6 +1,6 @@
 ---
 title: Next Steps
-nav_order: 100
+nav_order: 101
 ---
 
 Hopefully, you have a good feel for how Jets works now. From here, there are a few resources that can help you continue along:

--- a/docs/_docs/polymorphic-node.md
+++ b/docs/_docs/polymorphic-node.md
@@ -1,6 +1,6 @@
 ---
 title: Polymorphic Node
-nav_order: 89
+nav_order: 90
 ---
 
 To write your Jets Lambda functions in node, it would look like this:

--- a/docs/_docs/polymorphic-python.md
+++ b/docs/_docs/polymorphic-python.md
@@ -1,6 +1,6 @@
 ---
 title: Polymorphic Python
-nav_order: 88
+nav_order: 89
 ---
 
 Polymorphic support for python works like so for the controller code:

--- a/docs/_docs/polymorphic-support.md
+++ b/docs/_docs/polymorphic-support.md
@@ -1,6 +1,6 @@
 ---
 title: Polymorphic Support
-nav_order: 87
+nav_order: 88
 ---
 
 ## What is polymorphic support?

--- a/docs/_docs/rails-support.md
+++ b/docs/_docs/rails-support.md
@@ -1,6 +1,6 @@
 ---
 title: 'Rails Support: Afterburner Mode'
-nav_order: 90
+nav_order: 91
 ---
 
 Jets supports deploying Rails applications sometimes without any changes to your code.  Note, this is an experimental feature.

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -119,7 +119,7 @@
         <li><a href="{% link _docs/extras/codebuild.md %}">Continuous Integration</a></li>
         <li><a href="{% link _docs/extras/deploy-stagger.md %}">Deploy Stagger</a></li>
         <li><a href="{% link _docs/extras/upgrading.md %}">Upgrading Guide</a></li>
-        <li><a href="{% link _docs/extras/internationalization.md %}">Upgrading Guide</a></li>
+        <li><a href="{% link _docs/extras/internationalization.md %}">Internationalization</a></li>
 
       </ul>
     </li>

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -119,6 +119,8 @@
         <li><a href="{% link _docs/extras/codebuild.md %}">Continuous Integration</a></li>
         <li><a href="{% link _docs/extras/deploy-stagger.md %}">Deploy Stagger</a></li>
         <li><a href="{% link _docs/extras/upgrading.md %}">Upgrading Guide</a></li>
+        <li><a href="{% link _docs/extras/internationalization.md %}">Upgrading Guide</a></li>
+
       </ul>
     </li>
     <li><a href="{% link _docs/polymorphic-support.md %}">Polymorphic Functions</a>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-nav_order: 95
+nav_order: 96
 ---
 
 **Q: How do I set cookies from Jets?**

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,6 +1,6 @@
 ---
 title: Support
-nav_order: 98
+nav_order: 99
 ---
 
 ## Getting Help

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,6 +28,6 @@ If you would like professional help, [BoltOps](https://www.boltops.com/) provide
 * Support: Troubleshooting, Debugging, Guidance, and Help
 * Development: Can help you develop a serverless application that essentially scales infinitely.
 * Training: Mentorship, education, and understanding how to leverage and use AWS and serverless paradigms.
-* Consulting: Can help review, design, and architect your serverless application. Can evaluate trade-offs, limits, and benefits. Or just provide general guidance. 
+* Consulting: Can help review, design, and architect your serverless application. Can evaluate trade-offs, limits, and benefits. Or just provide general guidance.
 
 {% include prev_next.md %}

--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $stdout.sync = true unless ENV["JETS_STDOUT_SYNC"] == "0"
 
 $:.unshift(File.expand_path("../", __FILE__))
@@ -23,6 +25,11 @@ module Jets
 
   class Error < StandardError; end
   extend Core # root, logger, etc
+end
+
+ActiveSupport.on_load(:i18n) do
+  I18n.load_path << File.expand_path("jets/locale/en.yml", __dir__)
+  I18n.default_locale = :en
 end
 
 Jets::Autoloaders.once.preload("#{__dir__}/jets/db.rb") # required for booter.rb: setup_db

--- a/lib/jets/locale/en.yml
+++ b/lib/jets/locale/en.yml
@@ -1,0 +1,2 @@
+en:
+  jets_welcome: "Welcome to Jets!"

--- a/spec/lib/jets/i18n_spec.rb
+++ b/spec/lib/jets/i18n_spec.rb
@@ -1,0 +1,7 @@
+describe "i18n" do
+  describe "default locale" do
+    it "is english" do
+      expect(I18n.default_locale).to eq(:en)
+    end
+  end
+end


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This will allow i18n to be used out of the box on jets.
As there is already some international adoption this seems like
a good idea.
<!--
Provide a description of what your pull request changes.
-->

## Context

Relevant issue: https://community.rubyonjets.com/t/i18n-is-not-working/212/3

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

This is a minor patch in my opinion. 
