### PR TITLE
Improve iam_policy configuration

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -175,7 +175,9 @@ class Jets::Application
   end
 
   def set_iam_policy
-    config.iam_policy ||= self.class.default_iam_policy
+    config.iam_policy ||= []
+    config.default_iam_policy ||= self.class.default_iam_policy
+    config.iam_policy = config.default_iam_policy | config.iam_policy
     config.managed_policy_definitions ||= [] # default empty
   end
 

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -10,18 +10,12 @@ class Jets::Application
           effect: "Allow",
           resource: "arn:aws:logs:#{Jets.aws.region}:#{Jets.aws.account}:log-group:/aws/lambda/#{project_namespace}-*",
         }
-        s3_bucket = Jets.aws.s3_bucket
         s3_readonly = {
-          action: ["s3:Get*", "s3:List*"],
+          action: ["s3:Get*", "s3:List*", "s3:HeadBucket"],
           effect: "Allow",
-          resource: "arn:aws:s3:::#{s3_bucket}*",
+          resource: "arn:aws:s3:::#{Jets.aws.s3_bucket}*",
         }
-        s3_bucket = {
-          action: ["s3:ListAllMyBuckets", "s3:HeadBucket"],
-          effect: "Allow",
-          resource: "arn:aws:s3:::*", # scoped to all buckets
-        }
-        policies = [logs, s3_readonly, s3_bucket]
+        policies = [logs, s3_readonly]
 
         cloudformation = {
           action: ["cloudformation:DescribeStacks", "cloudformation:DescribeStackResources"],

--- a/spec/lib/jets/application_spec.rb
+++ b/spec/lib/jets/application_spec.rb
@@ -58,13 +58,22 @@ describe Jets::Application do
                                        ])
     end
 
-    it "sets iam_policy to app.class.default_iam_policy neither iam_policy nor default_iam_policy are set" do
+    it "sets iam_policy to app.class.default_iam_policy iam_policy and default_iam_policy are unset" do
       app.configure do
         config.default_iam_policy = nil
         config.iam_policy = nil
         set_iam_policy
       end
       expect(config.iam_policy).to eql(app.class.default_iam_policy)
+    end
+
+    it "sets iam_policy to empty when iam_policy and default_iam_policy are empty" do
+      app.configure do
+        config.default_iam_policy = []
+        config.iam_policy = []
+        set_iam_policy
+      end
+      expect(config.iam_policy).to eql([])
     end
   end
 

--- a/spec/lib/jets/application_spec.rb
+++ b/spec/lib/jets/application_spec.rb
@@ -58,7 +58,7 @@ describe Jets::Application do
                                        ])
     end
 
-    it "sets iam_policy to app.class.default_iam_policy iam_policy and default_iam_policy are unset" do
+    it "sets iam_policy to app.class.default_iam_policy when iam_policy and default_iam_policy are unset" do
       app.configure do
         config.default_iam_policy = nil
         config.iam_policy = nil

--- a/spec/lib/jets/application_spec.rb
+++ b/spec/lib/jets/application_spec.rb
@@ -45,6 +45,27 @@ describe Jets::Application do
     it "Rails constant should not be defined" do
       expect { Rails }.to raise_error(NameError)
     end
+
+    it "sets iam_policy by concatenating default_iam_policy" do
+      app.configure do
+        config.default_iam_policy = [{ effect: 'Fly', resource: "arn:aws:bird:::*" }]
+        config.iam_policy = [{ effect: 'Fire', resource: "arn:aws:gun:::*" }]
+        set_iam_policy
+      end
+      expect(config.iam_policy).to eql([
+                                         { effect: 'Fly', resource: "arn:aws:bird:::*" },
+                                         { effect: 'Fire', resource: "arn:aws:gun:::*" }
+                                       ])
+    end
+
+    it "sets iam_policy to app.class.default_iam_policy neither iam_policy nor default_iam_policy are set" do
+      app.configure do
+        config.default_iam_policy = nil
+        config.iam_policy = nil
+        set_iam_policy
+      end
+      expect(config.iam_policy).to eql(app.class.default_iam_policy)
+    end
   end
 
   context "database configurations" do

--- a/spec/lib/jets/resource/iam/class_role_spec.rb
+++ b/spec/lib/jets/resource/iam/class_role_spec.rb
@@ -15,12 +15,9 @@ describe Jets::Resource::Iam::ClassRole do
             "Effect"=>"Allow",
             "Resource"=>
              "arn:aws:logs:us-east-1:123456789:log-group:/aws/lambda/demo-test-*"},
-           {"Action"=>["s3:Get*", "s3:List*"],
+           {"Action"=>["s3:Get*", "s3:List*", "s3:HeadBucket"],
             "Effect"=>"Allow",
             "Resource"=>"arn:aws:s3:::fake-test-s3-bucket*"},
-           {"Action"=>["s3:ListAllMyBuckets", "s3:HeadBucket"],
-            "Effect"=>"Allow",
-            "Resource"=>"arn:aws:s3:::*"},
            {"Action"=>
              ["cloudformation:DescribeStacks",
               "cloudformation:DescribeStackResources"],

--- a/spec/lib/jets/resource/iam/function_role_spec.rb
+++ b/spec/lib/jets/resource/iam/function_role_spec.rb
@@ -19,12 +19,9 @@ describe Jets::Resource::Iam::FunctionRole do
             "Effect"=>"Allow",
             "Resource"=>
              "arn:aws:logs:us-east-1:123456789:log-group:/aws/lambda/demo-test-*"},
-           {"Action"=>["s3:Get*", "s3:List*"],
+           {"Action"=>["s3:Get*", "s3:List*", "s3:HeadBucket"],
             "Effect"=>"Allow",
             "Resource"=>"arn:aws:s3:::fake-test-s3-bucket*"},
-           {"Action"=>["s3:ListAllMyBuckets", "s3:HeadBucket"],
-            "Effect"=>"Allow",
-            "Resource"=>"arn:aws:s3:::*"},
            {"Action"=>
              ["cloudformation:DescribeStacks",
               "cloudformation:DescribeStackResources"],


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* Tightens default app-wide IAM policy to no longer allow `ListAllMyBuckets` and `HeadBucket` to all buckets in the AWS account
* Makes it easier to override the app-wide IAM policy and its defaults

## Context

Resolves https://github.com/tongueroo/jets/issues/455

## Version Changes

Major.
Apps that override `iam_policy` currently will also need to update `default_iam_policy` after this change to maintain identical behavior.
I'm open to toning down the changes to avoid this.

