### PR TITLE
Feature/base path

### DIFF
--- a/docs/_docs/routing/custom-domain.md
+++ b/docs/_docs/routing/custom-domain.md
@@ -103,6 +103,19 @@ end
 
 Though apex records are supported, it is recommended to put CloudFront of the API Gateway Custom Domain instead.
 
+## CustonDomain Base Path
+
+You can configure the base path in the custom domain by adding the base_path parameter . Example:
+
+```ruby
+Jets.application.configure do
+  config.domain.cert_arn = "arn:aws:acm:us-west-2:112233445577:certificate/8d8919ce-a710-4050-976b-b33da991e7e8" # String
+  config.domain.hosted_zone_name = "coolapp.com" # String
+  config.domain.name = "coolapp.com"
+  config.domain.base_path = "accounts"
+end
+```
+
 ## CloudFront Recommendation
 
 For the most control, it is recommended to create a CloudFront distribution **outside** of Jets. Then put CloudFront in front of the API Gateway Custom Domain.  Example:

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -91,7 +91,6 @@ module Jets::Cfn::Builders
         stack_name: api_gateway_physical_resource_id,
         logical_resource_id: "DnsRecord"
       }).stack_resource_detail
-      pp "teste"
       return true
     rescue
       return false

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -44,7 +44,9 @@ module Jets::Cfn::Builders
     end
 
     def add_domain_name
+      pp "Entrei!"
       domain_name = create_domain_name()
+      pp domain_name
       add_outputs(domain_name)
     end
 

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -80,7 +80,7 @@ module Jets::Cfn::Builders
       cfn.describe_stack_resource({
         stack_name: api_gateway_physical_resource_id,
         logical_resource_id: "DomainName"
-      }).stack_resource_detail
+      })
       return true
     rescue
       return false
@@ -90,14 +90,14 @@ module Jets::Cfn::Builders
       cfn.describe_stack_resource({
         stack_name: api_gateway_physical_resource_id,
         logical_resource_id: "DnsRecord"
-      }).stack_resource_detail
+      })
       return true
     rescue
       return false
     end
 
     def api_gateway_physical_resource_id
-      stack_resource_detail = cfn.describe_stack_resource({
+      cfn.describe_stack_resource({
         stack_name: Jets::Naming.parent_stack_name,
         logical_resource_id: "ApiGateway"
       })

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -74,7 +74,7 @@ module Jets::Cfn::Builders
         domain_name: domain_name.domain_name
       })
     rescue
-      retrun nil
+      return nil
     end
     memoize :get_existing_domain_name
 

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -44,14 +44,18 @@ module Jets::Cfn::Builders
 
     def add_domain_name
       domain_name = Jets::Resource::ApiGateway::DomainName.new
-      add_resource(domain_name)
-      add_outputs(domain_name.outputs)
+      #add_resource(domain_name)
+      add_outputs({
+        "DomainName" => "api.sbx.rvhub.com.br",
+      })
     end
 
     def add_route53_dns
       dns = Jets::Resource::Route53::RecordSet.new
-      add_resource(dns)
-      add_outputs(dns.outputs)
+      #add_resource(dns)
+      add_outputs({
+        "DomainName" => "api.sbx.rvhub.com.br",
+      })
     end
 
     # Adds route related Resources and Outputs

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -13,7 +13,10 @@ module Jets::Controller::Rack
       options = {}
       options = add_top_level(options)
       options = add_http_headers(options)
+      pp "INICIO"
       path = path_with_base_path || @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
+      pp "PATH: #{path}"
+
       env = Rack::MockRequest.env_for(path, options)
       if @options[:adapter]
         env['adapter.event'] = @event
@@ -25,7 +28,9 @@ module Jets::Controller::Rack
   private
     def path_with_base_path
       resource = @event['resource']
+      pp "RESOURCE: #{resource}"
       pathParameters = @event['pathParameters']
+      pp "PATH_PARAMETERS: #{pathParameters}"
       
       if(!pathParameters.nil? and !resource.nil?)
         resource = pathParameters.reduce(resource) {|resource, parameter|

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -14,6 +14,7 @@ module Jets::Controller::Rack
       options = add_top_level(options)
       options = add_http_headers(options)
       pp "INICIO"
+      pp "EVENT_PATH: #{@event['path']}"
       path = path_with_base_path || @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
       pp "PATH: #{path}"
 

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -36,7 +36,8 @@ module Jets::Controller::Rack
       if(!pathParameters.nil? and !resource.nil?)
         resource = pathParameters.reduce(resource) {|resource, parameter|
           key, value = parameter
-          resource = resource.gsub("{#{key}}", value)
+          resource = resource.gsub("{#{key}}", value) unless key.eql?("catchall")
+          resource = resource.gsub("{#{key}+}", value) if key.eql?("catchall")
           resource
         }
       end

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -13,10 +13,7 @@ module Jets::Controller::Rack
       options = {}
       options = add_top_level(options)
       options = add_http_headers(options)
-      pp "INICIO"
-      pp "EVENT_PATH: #{@event['path']}"
       path = path_with_base_path || @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
-      pp "PATH: #{path}"
 
       env = Rack::MockRequest.env_for(path, options)
       if @options[:adapter]
@@ -29,9 +26,7 @@ module Jets::Controller::Rack
   private
     def path_with_base_path
       resource = @event['resource']
-      pp "RESOURCE: #{resource}"
       pathParameters = @event['pathParameters']
-      pp "PATH_PARAMETERS: #{pathParameters}"
       
       if(!pathParameters.nil? and !resource.nil?)
         resource = pathParameters.reduce(resource) {|resource, parameter|

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -36,8 +36,8 @@ module Jets::Controller::Rack
       if(!pathParameters.nil? and !resource.nil?)
         resource = pathParameters.reduce(resource) {|resource, parameter|
           key, value = parameter
-          resource = resource.gsub("{#{key}}", value) unless key.eql?("catchall")
-          resource = resource.gsub("{#{key}+}", value) if key.eql?("catchall")
+          key = key.eql?("catchall") ? "{#{key}+}" : "{#{key}}"
+          resource = resource.gsub(key, value)
           resource
         }
       end

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -13,9 +13,6 @@ module Jets::Controller::Rack
       options = {}
       options = add_top_level(options)
       options = add_http_headers(options)
-      pp "MeuOvo"
-      path_with_base_path = @event['resource'] if @event['path'] != @event['resource']
-      pp path_with_base_path
       path = path_with_base_path || @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
       env = Rack::MockRequest.env_for(path, options)
       if @options[:adapter]
@@ -26,6 +23,19 @@ module Jets::Controller::Rack
     end
 
   private
+    def path_with_base_path
+      resource = @event['resource']
+      pathParameters = @event['pathParameters']
+      
+      resource = pathParameters.reduce(resource) {|resource, parameter|
+        key, value = parameter
+        resource = resource.gsub("{#{key}}", value)
+        resource
+      } unless pathParameters.nil?
+
+      resource
+    end
+
     def add_top_level(options)
       map = {
         'CONTENT_TYPE' => content_type,

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -13,7 +13,10 @@ module Jets::Controller::Rack
       options = {}
       options = add_top_level(options)
       options = add_http_headers(options)
-      path = @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
+      pp "MeuOvo"
+      path_with_base_path = @event['resource'] if @event['path'] != @event['resource']
+      pp path_with_base_path
+      path = path_with_base_path || @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
       env = Rack::MockRequest.env_for(path, options)
       if @options[:adapter]
         env['adapter.event'] = @event

--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -27,11 +27,13 @@ module Jets::Controller::Rack
       resource = @event['resource']
       pathParameters = @event['pathParameters']
       
-      resource = pathParameters.reduce(resource) {|resource, parameter|
-        key, value = parameter
-        resource = resource.gsub("{#{key}}", value)
-        resource
-      } unless pathParameters.nil?
+      if(!pathParameters.nil? and !resource.nil?)
+        resource = pathParameters.reduce(resource) {|resource, parameter|
+          key, value = parameter
+          resource = resource.gsub("{#{key}}", value)
+          resource
+        }
+      end
 
       resource
     end

--- a/lib/jets/internal/app/functions/jets/base_path.rb
+++ b/lib/jets/internal/app/functions/jets/base_path.rb
@@ -85,7 +85,7 @@ class BasePathMapping
     @event = event
     @rest_api_id = get_rest_api_id
     @domain_name = get_domain_name
-    @base_path = ''
+    @base_path = get_base_path || ''
   end
 
   def update
@@ -104,7 +104,7 @@ class BasePathMapping
   def delete(fail_silently=false)
     apigateway.delete_base_path_mapping(
       domain_name: @domain_name, # required
-      base_path: '(none)',
+      base_path: @base_path == '' ? '(none)' : @base_path,
     )
   # https://github.com/tongueroo/jets/issues/255
   # Used to return: Aws::APIGateway::Errors::NotFoundException
@@ -134,6 +134,11 @@ class BasePathMapping
 
   def get_rest_api_id
     param = deployment_stack[:parameters].find { |p| p.parameter_key == 'RestApi' }
+    param.parameter_value
+  end
+
+  def get_base_path
+    param = deployment_stack[:parameters].find { |p| p.parameter_key == 'BasePath' }
     param.parameter_value
   end
 

--- a/lib/jets/overrides/lambda/marshaller.rb
+++ b/lib/jets/overrides/lambda/marshaller.rb
@@ -16,6 +16,10 @@ module AwsLambda
       # Finally, StringIO/IO is used to signal a response that shouldn't be
       # formatted as JSON, and should get a different content-type header.
       def marshall_response(method_response)
+
+        pp "MEUOVO"
+        pp method_response
+
         case method_response
         when StringIO, IO
           [method_response, 'application/unknown']

--- a/lib/jets/overrides/lambda/marshaller.rb
+++ b/lib/jets/overrides/lambda/marshaller.rb
@@ -16,10 +16,6 @@ module AwsLambda
       # Finally, StringIO/IO is used to signal a response that shouldn't be
       # formatted as JSON, and should get a different content-type header.
       def marshall_response(method_response)
-
-        pp "MEUOVO"
-        pp method_response
-
         case method_response
         when StringIO, IO
           [method_response, 'application/unknown']

--- a/lib/jets/resource/api_gateway/deployment.rb
+++ b/lib/jets/resource/api_gateway/deployment.rb
@@ -20,6 +20,7 @@ module Jets::Resource::ApiGateway
         "S3Bucket" => "S3Bucket",
       }
       p[:DomainName] = "DomainName" if Jets.custom_domain?
+      p[:BasePath] = "BasePath" unless Jets.config.domain.base_path.nil?
       p
     end
 

--- a/lib/jets/resource/child_stack/api_deployment.rb
+++ b/lib/jets/resource/child_stack/api_deployment.rb
@@ -25,6 +25,7 @@ module Jets::Resource::ChildStack
         S3Bucket: "!Ref S3Bucket",
       }
       p[:DomainName] = "!GetAtt ApiGateway.Outputs.DomainName" if Jets.custom_domain?
+      p[:BasePath] = Jets.config.domain.base_path unless Jets.config.domain.base_path.nil?
       p
     end
 

--- a/lib/jets/version.rb
+++ b/lib/jets/version.rb
@@ -1,3 +1,3 @@
 module Jets
-  VERSION = "2.3.16"
+  VERSION = "2.3.17"
 end

--- a/lib/jets/version.rb
+++ b/lib/jets/version.rb
@@ -1,3 +1,3 @@
 module Jets
-  VERSION = "2.3.17"
+  VERSION = "2.3.16"
 end

--- a/spec/lib/jets/cfn/builders/api_gateway_builder_spec.rb
+++ b/spec/lib/jets/cfn/builders/api_gateway_builder_spec.rb
@@ -1,4 +1,5 @@
 describe Jets::Cfn::Builders::ApiGatewayBuilder do
+
   let(:builder) do
     Jets::Cfn::Builders::ApiGatewayBuilder.new({})
   end
@@ -9,9 +10,59 @@ describe Jets::Cfn::Builders::ApiGatewayBuilder do
       # puts builder.text # uncomment to see template text
 
       resources = builder.template["Resources"]
+      resources
       expect(resources).to include("RestApi")
 
       expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-gateway.yml"
     end
+
+    it "must create the DomainName and DnsRecord" do
+      allow(Jets.config.domain).to receive(:name).and_return("demo-test.example.com")
+      allow(Jets.config.domain).to receive(:hosted_zone_name).and_return("example.com")
+      
+      builder.compose
+
+      resources = builder.template["Resources"]
+
+      expect(resources).to include("DomainName")
+      expect(resources).to include("DnsRecord")
+    end
+
+    it "must exclude DomainName and DnsRecord" do
+      allow(Jets.config.domain).to receive(:name).and_return("124demo-test.example.com")
+      allow(Jets.config.domain).to receive(:hosted_zone_name).and_return("example.com")
+      
+      allow(builder.apigateway).to receive(:get_domain_name).and_return({})
+      allow(builder.cfn).to receive(:describe_stack_resource).with(hash_including(:logical_resource_id => "ApiGateway")).and_return(nil)
+      allow(builder.cfn).to receive(:describe_stack_resource).with(hash_including(:logical_resource_id => "DomainName")).and_throw(:this_symbol)
+      allow(builder.cfn).to receive(:describe_stack_resource).with(hash_including(:logical_resource_id => "DnsRecord")).and_throw(:this_symbol)
+      
+      
+      builder.compose
+
+      resources = builder.template["Resources"]
+      
+      expect(resources).to_not include("DomainName")
+      expect(resources).to_not include("DnsRecord")
+    end
+
+    it "should not exclude DomainName and DnsRecord" do
+      allow(Jets.config.domain).to receive(:name).and_return("124demo-test.example.com")
+      allow(Jets.config.domain).to receive(:hosted_zone_name).and_return("example.com")
+      
+      allow(builder.apigateway).to receive(:get_domain_name).and_return({})
+      allow(builder.cfn).to receive(:describe_stack_resource).with(hash_including(:logical_resource_id => "ApiGateway")).and_return(nil)
+      allow(builder.cfn).to receive(:describe_stack_resource).with(hash_including(:logical_resource_id => "DomainName")).and_return({})
+      allow(builder.cfn).to receive(:describe_stack_resource).with(hash_including(:logical_resource_id => "DnsRecord")).and_return({})
+      
+      
+      builder.compose
+
+      resources = builder.template["Resources"]
+      
+      expect(resources).to include("DomainName")
+      expect(resources).to include("DnsRecord")
+    end
   end
+
 end

--- a/spec/lib/jets/cfn/builders/api_gateway_builder_spec.rb
+++ b/spec/lib/jets/cfn/builders/api_gateway_builder_spec.rb
@@ -10,7 +10,7 @@ describe Jets::Cfn::Builders::ApiGatewayBuilder do
       # puts builder.text # uncomment to see template text
 
       resources = builder.template["Resources"]
-      resources
+
       expect(resources).to include("RestApi")
 
       expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-gateway.yml"
@@ -26,6 +26,9 @@ describe Jets::Cfn::Builders::ApiGatewayBuilder do
 
       expect(resources).to include("DomainName")
       expect(resources).to include("DnsRecord")
+      expect(resources).to include("RestApi")
+
+      expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-gateway.yml"
     end
 
     it "must exclude DomainName and DnsRecord" do
@@ -44,6 +47,9 @@ describe Jets::Cfn::Builders::ApiGatewayBuilder do
       
       expect(resources).to_not include("DomainName")
       expect(resources).to_not include("DnsRecord")
+      expect(resources).to include("RestApi")
+
+      expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-gateway.yml"
     end
 
     it "should not exclude DomainName and DnsRecord" do
@@ -62,6 +68,9 @@ describe Jets::Cfn::Builders::ApiGatewayBuilder do
       
       expect(resources).to include("DomainName")
       expect(resources).to include("DnsRecord")
+      expect(resources).to include("RestApi")
+
+      expect(builder.template_path).to eq "#{Jets.build_root}/templates/demo-test-api-gateway.yml"
     end
   end
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [X] I've added tests (if it's a bug, feature or enhancement)
- [X] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I had to configure the AWS Gateway base path on some projects. The challenge was that I had to use the same domain name and the latest version of the Jets. This feature has not yet been implemented.

## Context

I have five projects that should have the same domain name and each one of them should have one base path. I looked on the code and found the lambda that is used to create the base path, therefore I altered the code to add the base path as configured on the application.rb on CustoDomain. As shown below: 

```ruby
Jets.application.configure do
  config.domain.cert_arn = "arn:aws:acm:us-west-2:112233445577:certificate/8d8919ce-a710-4050-976b-b33da991e7e8" # String
  config.domain.hosted_zone_name = "coolapp.com" # String
  config.domain.name = "coolapp.com"
  config.domain.base_path = "accounts"
end
```

I also altered the Api Gateway builder. As the projects use the same domain name, I added some logic to check if they add the DnsRecord and CustomDomain features. If I do not add the change, when deploying the other projects that use the same domain name, the deployment will be incorrect.

## How to Test

You can test the feature by adding the new parameter config.domain.base_path in the application.rb. The value configured in this file is used to configure de base path on CustomDomain.

## Version Changes

2.3.17

## Final considerations:

- The new features is backward compatible, all changes was did to secure the backward compatible. 

- There is a lib/ jets/internal/app/functions/jets/base_path.rb class I couldn't write the unit test. I don’t find the good way to do that. I accept suggestions to do that.
