### PR TITLE
Add retry_limit and read_timeout options

### DIFF
--- a/lib/jets/commands/call.rb
+++ b/lib/jets/commands/call.rb
@@ -1,6 +1,5 @@
 require "base64"
 require "json"
-require "aws-sdk-lambda"
 
 class Jets::Commands::Call
   include Jets::AwsServices
@@ -61,17 +60,8 @@ class Jets::Commands::Call
       qualifier: @qualifier, # "1",
     }
 
-    opt = {}
-    opt = opt.merge({retry_limit: @options[:retry_limit]}) if @options[:retry_limit].present?
-    opt = opt.merge({http_read_timeout: @options[:read_timeout]}) if @options[:read_timeout].present?
-
-    client = if opt.empty?
-               aws_lambda
-             else
-               Aws::Lambda::Client.new(opt)
-             end
     begin
-      resp = client.invoke(options)
+      resp = lambda_client.invoke(options)
     rescue Aws::Lambda::Errors::ResourceNotFoundException
       puts "The function #{function_name} was not found.  Maybe check the spelling or the AWS_PROFILE?".color(:red)
       return
@@ -175,6 +165,18 @@ class Jets::Commands::Call
   #   jets call posts_controller-index '{"test":1}' | jq .
   def puts(text)
     $stderr.puts(text)
+  end
+
+  def lambda_client
+    opt = {}
+    opt = opt.merge({retry_limit: @options[:retry_limit]}) if @options[:retry_limit].present?
+    opt = opt.merge({http_read_timeout: @options[:read_timeout]}) if @options[:read_timeout].present?
+
+    if opt.empty?
+      aws_lambda
+    else
+      Aws::Lambda::Client.new(opt)
+    end
   end
 
 end

--- a/lib/jets/commands/help/call.md
+++ b/lib/jets/commands/help/call.md
@@ -53,6 +53,14 @@ Jets figures out what functions to call by evaluating the app code and finds if 
 
     jets call admin-related_pages_controller-index --no-guess
 
+If you want to call a function which runs too long time, you can set `read_timeout`.
+
+    jets call some_long_job-index --read_timeout 900
+    
+And you can set `retry_limit`. If you don't want to retry you can set 0.
+
+    jets call some_long_job-index --retry_limit 0
+
 ## Local mode
 
 Instead of calling AWS lambda remote, you can also have `jets call` use the code directly on your machine.  To enable this, use the `--local` flag. Example:

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -83,6 +83,8 @@ module Jets::Commands
     option :lambda_proxy, type: :boolean, default: true, desc: "Enables automatic Lambda proxy transformation of the event payload"
     option :guess, type: :boolean, default: true, desc: "Enables guess mode. Uses inference to allows use of all dashes to specify functions. Guess mode verifies that the function exists in the code base."
     option :local, type: :boolean, desc: "Enables local mode. Instead of invoke the AWS Lambda function, the method gets called locally with current app code. With local mode guess mode is always used."
+    option :retry_limit, type: :numeric, default: nil, desc: "Retry count of invoking function. It work with remote call"
+    option :read_timeout, type: :numeric, default: nil, desc: " The number of seconds to wait for response data. It work with remote call"
     def call(function_name, payload='')
       # Printing to stdout can mangle up the response when piping
       # the value to jq. For example:

--- a/spec/lib/jets/commands/call_spec.rb
+++ b/spec/lib/jets/commands/call_spec.rb
@@ -1,6 +1,7 @@
 describe Jets::Commands::Call do
+  let(:options) { { mute: true } }
   let(:call) do
-    call = Jets::Commands::Call.new(provided_function_name, event, mute: true)
+    call = Jets::Commands::Call.new(provided_function_name, event, options)
     allow(call).to receive(:aws_lambda).and_return(null)
     call
   end
@@ -57,6 +58,32 @@ describe Jets::Commands::Call do
         text = call.transformed_event
         event = JSON.load(text)
         expect(event["queryStringParameters"]).to eq("id" => "tung")
+      end
+    end
+  end
+
+  context "lambda_client with" do
+    let(:provided_function_name) { "posts-controller-index" }
+    let(:event) { nil }
+
+    context "no specific options" do
+      let(:options) { { mute: true }}
+      it "returns default client" do
+        expect(call.lambda_client).to be(null)
+      end
+    end
+
+    context "with retry_limit" do
+      let(:options) { { mute: true, retry_limit: 1 }}
+      it "create new Aws::Lambda::Client with options" do
+        expect(call.lambda_client.config.retry_limit).to eq(1)
+      end
+    end
+
+    context "with read_timeout" do
+      let(:options) { { mute: true, read_timeout: 900 }}
+      it "create new Aws::Lambda::Client with options" do
+        expect(call.lambda_client.config.http_read_timeout).to eq(900)
       end
     end
   end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

## Context

When `jets call` is run for a function that requires too long execution time, the timeout error happens and the lambda client makes requests to retry.
Sometimes users don't want the behavior.

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

Create and deploy a function that requires to execute more than 1 sec, and then call the function with `--read_timeout 1 --retry_limit 0`

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

