### PR TITLE
Fix queryStringParameters handling for nested value in spec_helper

### DIFF
--- a/lib/jets/spec_helpers/controllers/request.rb
+++ b/lib/jets/spec_helpers/controllers/request.rb
@@ -46,7 +46,7 @@ module Jets::SpecHelpers::Controllers
 
       params.query_params.each do |key, value|
         json['queryStringParameters'] ||= {}
-        json['queryStringParameters'][key.to_s] = value.to_s
+        json['queryStringParameters'][key.to_s] = value.deep_dup
       end
 
       json

--- a/spec/lib/jets/spec_helpers_spec.rb
+++ b/spec/lib/jets/spec_helpers_spec.rb
@@ -62,6 +62,12 @@ describe Jets::SpecHelpers do
       expect(JSON.parse(response.body)['filter']).to eq 'abc'
     end
 
+    it "gets 200 with nested query params" do
+      get '/spec_helper_test/:id', id: 123, query: { filter: ['abc', 'def'] }
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['filter']).to eq ['abc', 'def']
+    end
+
     it "gets 200 with query params no query keyword" do
       get '/spec_helper_test/:id', id: 123, filter: 'abc'
       expect(response.status).to eq 200


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] ~I've adjusted the documentation (if it's a feature or enhancement)~
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

https://github.com/tongueroo/jets/blob/91a7bf7f/lib/jets/spec_helpers/controllers/request.rb#L49

```ruby
      params.query_params.each do |key, value|
        json['queryStringParameters'] ||= {}
        json['queryStringParameters'][key.to_s] = value.to_s
      end
```
In Request class of spec_helper, value is converted to string.
But the value can be array or hash. It must not convert to string.

## Context

n/a

## How to Test

Please see [first commit test result](https://app.circleci.com/pipelines/github/tongueroo/jets/86/workflows/6849f173-341e-4fb6-aec4-402f84822770/jobs/3177/steps). Then check [second commit fixes it](https://app.circleci.com/pipelines/github/tongueroo/jets/87/workflows/7fe5bddd-8c69-44c8-97ba-bdaf5f188c59/jobs/3178/steps).

## Version Changes

Nothing