### PR TITLE
Add params keyword case with get method for spec helpers test

### DIFF
--- a/lib/jets/spec_helpers/controllers.rb
+++ b/lib/jets/spec_helpers/controllers.rb
@@ -25,10 +25,17 @@ module Jets::SpecHelpers
       request.path = path
       request.headers.deep_merge!(params.delete(:headers) || {})
 
-      request.params.body_params = params.delete(:params) || params || {}
-
       request.params.query_params = params.delete(:query)
-      request.params.query_params ||= params if request.method == :get
+
+      if request.method == :get
+        request.params.body_params = {}
+        request.params.query_params ||= params.delete(:params)
+        request.params.query_params ||= params
+      else
+        request.params.body_params = params.delete(:params)
+        request.params.body_params ||= params
+      end
+
       request.params.query_params ||= {}
 
       request.params.path_params = params

--- a/spec/lib/jets/spec_helpers_spec.rb
+++ b/spec/lib/jets/spec_helpers_spec.rb
@@ -62,6 +62,12 @@ describe Jets::SpecHelpers do
       expect(JSON.parse(response.body)['filter']).to eq 'abc'
     end
 
+    it "gets 200 with query params with params keyword" do
+      get '/spec_helper_test/:id', id: 123, params: { filter: 'abc' }
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['filter']).to eq 'abc'
+    end
+
     it "gets 200 with query params no query keyword" do
       get '/spec_helper_test/:id', id: 123, filter: 'abc'
       expect(response.status).to eq 200


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] ~I've adjusted the documentation (if it's a feature or enhancement)~
    - This is compatibility behavior then I think no need to document
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Spec helper method `get` in rails accepts params keyword value as query parameter.
This PR adds it behavior for compatibility.

Rails test: https://github.com/rails/rails/blob/master/actionpack/test/controller/integration_test.rb#L442

## Context

n/a

## How to Test

Please see [first commit test result](https://app.circleci.com/pipelines/github/tongueroo/jets/88/workflows/437c2e7f-0c30-45b5-a235-8ff8f0f01af7/jobs/3179/steps). Then check [second commit fixes it](https://app.circleci.com/pipelines/github/tongueroo/jets/89/workflows/f426dfcd-e052-4325-a503-f6316127fbe3/jobs/3180/steps).

## Version Changes

This is behavior changes. Is version up needed ?
