### PR TITLE
Add unicode test for spec_helpers test

### DIFF
--- a/lib/jets/router/dsl.rb
+++ b/lib/jets/router/dsl.rb
@@ -5,7 +5,7 @@ class Jets::Router
     # Methods supported by API Gateway
     %w[any delete get head options patch post put].each do |method_name|
       define_method method_name do |path, options={}|
-        create_route(options.merge(path: path, method: __method__))
+        create_route(options.merge(path: escape_path(path), method: __method__))
       end
     end
 
@@ -133,6 +133,11 @@ class Jets::Router
       options = default.merge(options)
       MethodCreator.new(options, @scope).create_root_helper
       @routes << Route.new(options, @scope)
+    end
+    private
+
+    def escape_path(path)
+      path.to_s.split('/').map { |s| s =~ /\A[:\*]/ ? s : CGI.escape(s) }.join('/')
     end
   end
 end

--- a/lib/jets/spec_helpers/controllers/request.rb
+++ b/lib/jets/spec_helpers/controllers/request.rb
@@ -10,7 +10,7 @@ module Jets::SpecHelpers::Controllers
     def event
       json = {}
       id_params = route.path.scan(%r{:([^/]+)}).flatten
-      expanded_path = path.dup
+      expanded_path = escape_path(path)
       path_parameters = {}
 
       id_params.each do |id_param|
@@ -19,11 +19,12 @@ module Jets::SpecHelpers::Controllers
         path_param_value = path_params[id_param.to_sym]
         raise "Path param :#{id_param} value cannot be blank" if path_param_value.blank?
 
-        expanded_path.gsub!(":#{id_param}", path_param_value.to_s)
-        path_parameters.deep_merge!(id_param => path_param_value.to_s)
+        escaped_path_param_value = CGI.escape(path_param_value.to_s)
+        expanded_path.gsub!(":#{id_param}", escaped_path_param_value)
+        path_parameters.deep_merge!(id_param => escaped_path_param_value)
       end
 
-      json['resource'] = path
+      json['resource'] = escape_path(path)
       json['path'] = expanded_path
       json['httpMethod'] = method.to_s.upcase
       json['pathParameters'] = path_parameters
@@ -83,6 +84,12 @@ module Jets::SpecHelpers::Controllers
       end
 
       Response.new(response) # converts APIGW hash to prettier object
+    end
+
+    private
+
+    def escape_path(path)
+      path.to_s.split('/').map { |s| s =~ /\A[:\*]/ ? s : CGI.escape(s) }.join('/')
     end
   end
 end

--- a/spec/lib/jets/spec_helpers_spec.rb
+++ b/spec/lib/jets/spec_helpers_spec.rb
@@ -34,7 +34,10 @@ describe Jets::SpecHelpers do
   before do
     Jets.application.routes.draw do
       get 'spec_helper_test', to: 'simple#index'
+      get 'ほげ', to: 'simple#index'
+
       get 'spec_helper_test/:id', to: 'simple#show'
+      get 'ほげ/:id', to: 'simple#show'
 
       post 'spec_helper_test', to: 'simple#create'
 
@@ -56,10 +59,27 @@ describe Jets::SpecHelpers do
       expect(JSON.parse(response.body)['id']).to eq '123'
     end
 
+    it "gets 200 with unicode" do
+      get '/ほげ'
+      expect(response.status).to eq 200
+    end
+
+    it "gets 200 with id and unicode" do
+      get '/ほげ/:id', id: 'ふが'
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['id']).to eq 'ふが'
+    end
+
     it "gets 200 with query params" do
       get '/spec_helper_test/:id', id: 123, query: { filter: 'abc' }
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)['filter']).to eq 'abc'
+    end
+
+    it "gets 200 with unicode query params" do
+      get '/spec_helper_test/:id', id: 123, query: { filter: 'ふが' }
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['filter']).to eq 'ふが'
     end
 
     it "gets 200 with query params no query keyword" do


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] ~I've adjusted the documentation (if it's a feature or enhancement)~
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Spec helper of Rails support UTF-8 path notation ( https://github.com/rails/rails/blob/49baf092/actionpack/test/dispatch/routing_test.rb#L4217-L4234 ).
This PR adds its support.

## Context

Nothing

## How to Test

Please see [first commit test result](https://app.circleci.com/pipelines/github/tongueroo/jets/92/workflows/ae8d89f3-6873-494b-95d4-d758cdc19abe/jobs/3183/steps). Then check [second commit fixes it](https://app.circleci.com/pipelines/github/tongueroo/jets/93/workflows/5275d164-fac1-4d67-9914-fb05a82a0f5d/jobs/3184/steps).