### PR TITLE
Add unicode body/path/query parameter decode in params

### DIFF
--- a/spec/lib/jets/controller/params_spec.rb
+++ b/spec/lib/jets/controller/params_spec.rb
@@ -1,6 +1,57 @@
 describe Jets::Controller::Params do
   let(:controller) { PostsController.new(event, nil, "update") }
 
+  context "with unicode" do
+    context "body parameter" do
+      let(:event) do
+        {
+          "headers" => {
+            "content-type" => "application/x-www-form-urlencoded; charset=UTF-8"
+          },
+          "body" => "name=#{CGI.escape("太郎")}&location=#{CGI.escape("東京")}"
+        }
+      end
+      it "decode values" do
+        params = controller.send(:params)
+        expect(params["name"]).to eq "太郎"
+      end
+    end
+
+    context "path parameter" do
+      let(:event) do
+        {
+          "pathParameters" => {
+            "name" => CGI.escape("太郎"),
+            "location" => CGI.escape("東京"),
+          }
+        }
+      end
+      it "decode values" do
+        params = controller.send(:params)
+        expect(params["name"]).to eq "太郎"
+      end
+    end
+
+    context "query parameter" do
+      let(:event) do
+        {
+          "queryStringParameters" => {
+            "name" => [
+              CGI.escape("太郎"),
+              CGI.escape("鈴木"),
+            ],
+            "location" => CGI.escape("東京"),
+          }
+        }
+      end
+      it "decode values" do
+        params = controller.send(:params)
+        expect(params["name"][0]).to eq "太郎"
+        expect(params["name"][1]).to eq "鈴木"
+      end
+    end
+  end
+
   context "update action called" do
     let(:event) do
       {


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] ~I've adjusted the documentation (if it's a feature or enhancement)~
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Rails decodes query/path/body parameters.
This PR adds decode process.

## Context

Nothing

## How to Test

Please see [first commit test result](https://app.circleci.com/jobs/github/tongueroo/jets/3185). Then check [second commit fixes it](https://app.circleci.com/pipelines/github/tongueroo/jets/95/workflows/21b7944c-8795-4ce9-a8d1-f7516019a818/jobs/3186/steps).