### PR TITLE
Fix custom resource path parameter names

### DIFF
--- a/lib/jets/router/dsl.rb
+++ b/lib/jets/router/dsl.rb
@@ -62,6 +62,7 @@ class Jets::Router
       {
         as: options.delete(:as) || item, # delete as or it messes with create_route
         prefix: prefix,
+        param: options[:param],
         # module: options.delete(:module) || item, # NOTE: resources does not automatically set module, but namespace does
       }
     end

--- a/lib/jets/router/scope.rb
+++ b/lib/jets/router/scope.rb
@@ -35,9 +35,13 @@ module Jets
 
           case current.from
           when :resources
-            variable = prefix.to_s.split('/').last
-            variable = ":#{variable.singularize}_id"
-            result.unshift(variable)
+            path_param = if current.options[:param]
+              ":#{current.options[:param]}"
+            else
+              resource_name = prefix.to_s.split('/').last
+              resource_name = ":#{resource_name.singularize}_id"
+            end
+            result.unshift(path_param)
             result.unshift(prefix)
           else # resource, namespace or general scope
             result.unshift(prefix)

--- a/spec/lib/jets/router_spec.rb
+++ b/spec/lib/jets/router_spec.rb
@@ -338,6 +338,58 @@ EOL
         expect(app.user_path(1)).to eq("/users/1")
         expect(app.edit_user_path(1)).to eq("/users/1/edit")
       end
+
+      it "param custom my_comment_id with block" do
+        router.draw do
+          resources :posts do
+            resources :comments, param: :my_comment_id, only: [:create] do
+              get :test, on: :member
+            end
+          end
+
+          resources :parent, param: :my_parent_id do
+            resources :child, only: [:create, :show], param: :my_child_id do
+              # nothing
+            end
+          end
+
+          resources :users, param: :my_user_id, only: [] do
+            get :test, on: :member
+          end
+        end
+
+        output = Jets::Router.help(router.routes).to_s
+        table =<<EOL
++--------------+--------+---------------------------------------------+-------------------+
+|      As      |  Verb  |                    Path                     | Controller#action |
++--------------+--------+---------------------------------------------+-------------------+
+| posts        | GET    | posts                                       | posts#index       |
+| new_post     | GET    | posts/new                                   | posts#new         |
+| post         | GET    | posts/:post_id                              | posts#show        |
+|              | POST   | posts                                       | posts#create      |
+| edit_post    | GET    | posts/:post_id/edit                         | posts#edit        |
+|              | PUT    | posts/:post_id                              | posts#update      |
+|              | POST   | posts/:post_id                              | posts#update      |
+|              | PATCH  | posts/:post_id                              | posts#update      |
+|              | DELETE | posts/:post_id                              | posts#delete      |
+|              | POST   | posts/:post_id/comments                     | comments#create   |
+| test_comment | GET    | posts/:post_id/comments/:my_comment_id/test | comments#test     |
+| parent       | GET    | parent                                      | parent#index      |
+| new_parent   | GET    | parent/new                                  | parent#new        |
+| parent       | GET    | parent/:my_parent_id                        | parent#show       |
+|              | POST   | parent                                      | parent#create     |
+| edit_parent  | GET    | parent/:my_parent_id/edit                   | parent#edit       |
+|              | PUT    | parent/:my_parent_id                        | parent#update     |
+|              | POST   | parent/:my_parent_id                        | parent#update     |
+|              | PATCH  | parent/:my_parent_id                        | parent#update     |
+|              | DELETE | parent/:my_parent_id                        | parent#delete     |
+| parent_child | GET    | parent/:my_parent_id/child/:my_child_id     | child#show        |
+|              | POST   | parent/:my_parent_id/child                  | child#create      |
+| test_user    | GET    | users/:my_user_id/test                      | users#test        |
++--------------+--------+---------------------------------------------+-------------------+
+EOL
+        expect(output).to eq(table)
+      end
     end
 
     context "singular resource" do


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Added `param` to `Jets::Router::Scope` options, which allows correct retention of custom path parameter names in resources (and nested resources).

## Context

Closes #510.

## How to Test

`bundle exec rspec spec/lib/jets/router_spec.rb`

## Version Changes

I recommend a patch version change.