### PR TITLE
Allow to define route that contains dot

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -66,4 +66,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "cfn-status"
 end

--- a/lib/jets/resource/api_gateway/method.rb
+++ b/lib/jets/resource/api_gateway/method.rb
@@ -96,7 +96,7 @@ module Jets::Resource::ApiGateway
     def camelized_path
       path = @route.path
       path = "homepage" if path == ''
-      path.gsub('/','_').gsub(':','').gsub('*','').camelize
+      path.gsub('/','_').gsub(':','').gsub('*','').gsub('.','').camelize
     end
   end
 end

--- a/lib/jets/resource/api_gateway/resource.rb
+++ b/lib/jets/resource/api_gateway/resource.rb
@@ -76,7 +76,7 @@ module Jets::Resource::ApiGateway
   private
     # Similar path_logical_id method in resource/route.rb
     def path_logical_id(path)
-      path.gsub('/','_').gsub(':','').gsub('*','').gsub('-','_').camelize
+      path.gsub('/','_').gsub(':','').gsub('*','').gsub('-','_').gsub('.','_').camelize
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/method_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/method_spec.rb
@@ -44,6 +44,26 @@ describe Jets::Resource::ApiGateway::Method do
     end
   end
 
+  context "route contains dot" do
+    let(:route) do
+      Jets::Router::Route.new(path: "v1.2/posts/:post_id/", method: :get, to: "posts#index")
+    end
+
+    it "route contains dot" do
+      expect(resource.logical_id).to eq "V12PostsPostIdIndexGetApiMethod"
+      expect(resource.logical_id.size).to eq 31
+    end
+
+    it "resource" do
+      expect(resource.logical_id).to eq "V12PostsPostIdIndexGetApiMethod"
+      properties = resource.properties
+      # pp properties # uncomment to debug
+      expect(properties["RestApiId"]).to eq "!Ref RestApi"
+      expect(properties["ResourceId"]).to eq "!Ref V12PostsPostIdApiResource"
+      expect(properties["HttpMethod"]).to eq "GET"
+    end
+  end
+
   context "authorization" do
     let(:route) do
       Jets::Router::Route.new(path: "posts", method: :get, to: "posts#index", authorization_type: 'AWS_IAM')

--- a/spec/lib/jets/resource/api_gateway/resource_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/resource_spec.rb
@@ -72,5 +72,15 @@ describe Jets::Resource::ApiGateway::Resource do
     end
   end
 
+  context("url.with.dot") do
+    let(:path) { "url.with.dot" }
+    it "contains info for CloudFormation API Gateway Resources" do
+      expect(resource.logical_id).to eq "UrlWithDotApiResource"
+      properties = resource.properties
+      expect(properties["PathPart"]).to eq "url.with.dot"
+      expect(properties["ParentId"]).to eq "!Ref RootResourceId"
+    end
+  end
+
 end
 


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When defining a dotted URL, CloudFormation failed during deployment with the following message

```
Template format error: Resource name V1.2PostsShowCorsApiMethod is non alphanumeric.
```

For example, if we'd like to define a path like `/v1.2/posts/123`, Jets will fail to deploy it.
So we'll fix that.

## Context

- none in particular

## How to Test

`bundle exec rspec spec/lib/jets/resource/api_gateway/resource_spec.rb spec/lib/jets/resource/api_gateway/resource_spec.rb`

or

Define route that contains dot.

```ruby
# config/routes.rb
Jets.application.routes.draw do
  scope prefix: :'v1.2' do
    get 'posts/:post_id', to: 'posts#show'
  end
end
```

and deploy to AWS.

## Version Changes

patch

@tongueroo Could you check it?