### PR TITLE
set content type on upload by using extension so cloudfront will compress when serving

### DIFF
--- a/lib/jets/cfn/upload.rb
+++ b/lib/jets/cfn/upload.rb
@@ -7,6 +7,13 @@ module Jets::Cfn
     include ActionView::Helpers::NumberHelper # number_to_human_size
 
     attr_reader :bucket_name
+
+    CONTENT_TYPES_BY_EXTENSION = {
+      '.css' => 'text/css',
+      '.js' => 'application/javascript',
+      '.html' => 'text/html'
+    }
+
     def initialize(bucket_name)
       @bucket_name = bucket_name
     end
@@ -91,17 +98,13 @@ module Jets::Cfn
       key = s3_key(full_path)
       obj = s3_resource.bucket(bucket_name).object(key)
       puts "Uploading and setting content type for s3://#{bucket_name}/#{key}" # uncomment to see and debug
-      obj.upload_file(full_path, { acl: "public-read", cache_control: cache_control }.merge(guess_content_type_headers(full_path)))
+      obj.upload_file(full_path, { acl: "public-read", cache_control: cache_control }.merge(content_type_headers(full_path)))
     end
 
-    def guess_content_type_headers(full_path)
-      case File.extname(full_path)
-      when '.css'
-        { content_type: "text/css" }
-      when '.js'
-        { content_type: 'application/javascript' }
-      when '.html'
-        { content_type: 'text/html' }
+    def content_type_headers(full_path)
+      content_type = CONTENT_TYPES_BY_EXTENSION[File.extname(full_path)]
+      if content_type
+        { content_type: content_type }
       else
         {}
       end

--- a/lib/jets/cfn/upload.rb
+++ b/lib/jets/cfn/upload.rb
@@ -90,8 +90,21 @@ module Jets::Cfn
 
       key = s3_key(full_path)
       obj = s3_resource.bucket(bucket_name).object(key)
-      puts "Uploading s3://#{bucket_name}/#{key}" # uncomment to see and debug
-      obj.upload_file(full_path, acl: "public-read", cache_control: cache_control)
+      puts "Uploading and setting content type for s3://#{bucket_name}/#{key}" # uncomment to see and debug
+      obj.upload_file(full_path, { acl: "public-read", cache_control: cache_control }.merge(guess_content_type_headers(full_path)))
+    end
+
+    def guess_content_type_headers(full_path)
+      case File.extname(full_path)
+      when '.css'
+        { content_type: "text/css" }
+      when '.js'
+        { content_type: 'application/javascript' }
+      when '.html'
+        { content_type: 'text/html' }
+      else
+        {}
+      end
     end
 
     def s3_key(full_path)


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement. 
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->
By default, cloudfront will not serve assets compressed. Even the ones generated pre-compressed with a webpacker build. However, if you set the content type in the s3 bucket with certain types, cloudfront will automatically compress the object when serving if the client indicates it can accept compressed content.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

