### PR TITLE
support nested query params in tests

### DIFF
--- a/lib/jets/spec_helpers/controllers/request.rb
+++ b/lib/jets/spec_helpers/controllers/request.rb
@@ -46,7 +46,7 @@ module Jets::SpecHelpers::Controllers
 
       params.query_params.each do |key, value|
         json['queryStringParameters'] ||= {}
-        json['queryStringParameters'][key.to_s] = value.to_s
+        json['queryStringParameters'][key.to_s] = value
       end
 
       json

--- a/spec/lib/jets/spec_helpers_spec.rb
+++ b/spec/lib/jets/spec_helpers_spec.rb
@@ -45,6 +45,18 @@ describe Jets::SpecHelpers do
   end
 
   context "get" do
+    let(:nested_params) do 
+      {
+        level_1: {
+          level_2: {
+            level_3: {
+
+            }
+          }
+        }
+      }.with_indifferent_access
+    end
+
     it "gets 200" do
       get '/spec_helper_test'
       expect(response.status).to eq 200
@@ -60,6 +72,13 @@ describe Jets::SpecHelpers do
       get '/spec_helper_test/:id', id: 123, query: { filter: 'abc' }
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)['filter']).to eq 'abc'
+    end
+
+    it "gets 200 with nested query params" do
+      get '/spec_helper_test/:id', id: 123, query: { filter: nested_params }
+
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)['filter']).to eq nested_params
     end
 
     it "gets 200 with query params no query keyword" do


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
support nested query params in the tests

## Context
#516 
we have an API in jets using [JSON:API specification](https://jsonapi.org/format/#fetching-filtering), when we try to send a request like this 

```ruby
# Test Request
get "/comments", query: { filter: { post: [1, 2], author: 12 } } # /comments?filter[post]=1,2&filter[author]=12


# controller
params['filter'] 
=> "{:post=>[1, 2], :author=>12}"
```
![image](https://user-images.githubusercontent.com/4649902/97632613-c2798c80-1a00-11eb-91d5-ac4195332087.png)

the controller receives the nested query params as a string with a bad format
<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test
```ruby
bundle exec spec/lib/jets/spec_helpers_spec.rb

```

