### PR TITLE
Fix Jets::Logger strerr -> stderr typo

### DIFF
--- a/lib/jets/commands/templates/skeleton/config/application.rb.tt
+++ b/lib/jets/commands/templates/skeleton/config/application.rb.tt
@@ -63,7 +63,7 @@ Jets.application.configure do
   # By default logger needs to log to $stderr for CloudWatch to receive Lambda messages, but for
   # local testing environment you may want to log these messages to 'test.log' file to keep your
   # testing suite output readable.
-  # config.logger = Jets::Logger.new($strerr)
+  # config.logger = Jets::Logger.new($stderr)
 
 <% if @options[:mode] == 'api' -%>
   config.controllers.default_protect_from_forgery = false


### PR DESCRIPTION
- I read the contributing document at https://rubyonjets.com/docs/contributing/


This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix a typo of `$strerr` instead of `$stderr` in a template used by the new-app generator.

## Context

https://github.com/boltops-tools/jets/pull/140

