### PR TITLE
Add config for Time.zone

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -22,6 +22,7 @@ class Jets::Application
     load_environments_config
     load_db_config
     set_iam_policy # relies on dependent values, must be called afterwards
+    set_time_zone
     normalize_env_vars!
   end
 
@@ -177,6 +178,10 @@ class Jets::Application
   def set_iam_policy
     config.iam_policy ||= self.class.default_iam_policy
     config.managed_policy_definitions ||= [] # default empty
+  end
+
+  def set_time_zone
+    Time.zone_default = Time.find_zone!(config.time_zone)
   end
 
   # It is pretty easy to attempt to set environment variables without

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -57,6 +57,7 @@ class Jets::Application
       config.autoload_paths = [] # allows for customization
       config.ignore_paths = [] # allows for customization
       config.logger = Jets::Logger.new($stderr)
+      config.time_zone = "UTC"
 
       # function properties defaults
       config.function = ActiveSupport::OrderedOptions.new

--- a/spec/lib/jets/application_spec.rb
+++ b/spec/lib/jets/application_spec.rb
@@ -36,6 +36,11 @@ describe Jets::Application do
       expect(config.function.memory_size).to eq 1536
     end
 
+    it "should have a default time zone defined" do
+      expect(config.time_zone).to eq "UTC"
+      expect(Time.zone).to eq Time.find_zone!("UTC")
+    end
+
     it "routes should be loaded" do
       router = app.routes
       expect(router).to be_a(Jets::Router)


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
Adds a default Time.zone (UTC seems a reasonable default)
Also allows user to change the the time zone via `config.time_zone` 

First PR, please advise :)

<!--
Provide a description of what your pull request changes.
-->

## Context
https://github.com/boltops-tools/jets/issues/427
<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test
Config the time zone by setting `config.time_zone = zone_name_here` in `config/application.rb`
Reference list: https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
Call Time.zone from application code.
<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes


