### PR TITLE
fix native gem detection

### DIFF
--- a/lib/jets/builders/gem_replacer.rb
+++ b/lib/jets/builders/gem_replacer.rb
@@ -20,9 +20,21 @@ module Jets::Builders
       found_gems.each do |gem_name|
         gem_extractor = Jets::Gems::Extract::Gem.new(gem_name, @options)
         gem_extractor.run
+        rename_gem(gem_name)
       end
 
       tidy
+    end
+
+    def rename_gem(gem_name)
+      ruby_folder = "#{Jets.build_root}/stage/opt/ruby/gems/#{Jets::Gems.ruby_folder}"
+      gems_folder = "#{ruby_folder}/gems"
+      expr = "#{gems_folder}/#{gem_name}-x*-{darwin,linux}"
+      src = Dir.glob(expr).first
+      return unless src
+
+      dest = src.sub("-darwin", "-linux")
+      FileUtils.mv(src, dest) unless File.exist?(dest) # looks like rename_gem actually runs twice
     end
 
     def sh(command)

--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -67,7 +67,7 @@ module Jets::Builders
       end
       create_bundle_config(frozen: true)
 
-      remove_bundled_with("#{cache_area}/Gemfile.lock")
+      rewrite_gemfile_lock("#{cache_area}/Gemfile.lock")
 
       # Copy the Gemfile.lock back to the project in case it was updated.
       # For example we add the jets-rails to the Gemfile.
@@ -149,9 +149,10 @@ module Jets::Builders
 
     # Remove the BUNDLED WITH line since we don't control the bundler gem version on AWS Lambda
     # And this can cause issues with require 'bundler/setup'
-    def remove_bundled_with(gemfile_lock)
+    def rewrite_gemfile_lock(gemfile_lock)
       lines = IO.readlines(gemfile_lock)
 
+      # Remove BUNDLED WITH
       # amount is the number of lines to remove
       new_lines, capture, count, amount = [], true, 0, 2
       lines.each do |l|
@@ -163,6 +164,27 @@ module Jets::Builders
           count += 1
           capture = count > amount # renable capture
         end
+      end
+
+      # Replace things like nokogiri (1.11.1-x86_64-darwin) => nokogiri (1.11.1)
+      lines, new_lines = new_lines, []
+      lines.each do |l|
+        if l.include?("-x86_64-darwin")
+          l = l.sub('-x86_64-darwin','')
+        end
+        new_lines << l
+      end
+
+      # Make sure platform is ruby
+      lines, new_lines, marker = new_lines, [], false
+      lines.each do |l|
+        if marker # the next loop has the platform we want to replace
+          new_lines << "  ruby\n"
+          marker = false
+          next
+        end
+        marker = l.include?('PLATFORMS')
+        new_lines << l
       end
 
       content = new_lines.join('')


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Looks like in a recent versions of either ruby or bundler changed native gems detection, specifically on macosx. Additionally, new version of bundler (tested bundler 2.2.5), writes macosx platform info to the Gemfile.lock. 

This PR fixes these issues.

## Context

#523 

## How to Test

Go through quick start on macosx.

## Version Changes

Patch
