### PR TITLE
Error custom layer

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -52,7 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jets-html-sanitizer"
   spec.add_dependency "kramdown"
   spec.add_dependency "memoist"
-  spec.add_dependency "mimemagic"
   spec.add_dependency "rack"
   spec.add_dependency "railties", "~> 6.1.0" # for ActiveRecord database_tasks.rb
   spec.add_dependency "rainbow"

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 755 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && chmod -R 744 . && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 755 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && chmod -R 755 . && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 655 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && chmod -R 666 . && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 744 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && chmod -R 655 . && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 644 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && chmod -R 644 . && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 655 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip

--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -23,7 +23,7 @@ module Jets::Builders
       # => Creating zip file for /tmp/jets/demo/stage/bundled
 
       # https://serverfault.com/questions/265675/how-can-i-zip-compress-a-symlink
-      command = "cd #{@path} && chmod -R 655 . && zip --symlinks -rq #{zip_file} ."
+      command = "cd #{@path} && chmod -R 666 . && zip --symlinks -rq #{zip_file} ."
       sh(command)
       # move out of the lower folder to the stage folder
       # mv /tmp/jets/demo/stage/code/code.zip /tmp/jets/demo/stage/code.zip


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Today I needed to add a custom layer to my jets project. After I generated the custom layer, I tried to add the new layer but I received the following error on the aws console: "Layer conversion failed: Some files need to be overridden by layers but don't have write permissions;"

## Context
This error occurs because in the layer generated by the Jets, the folders do not have write permission per group.

I’ve fixed this error by changing the line below the md5_zip.rb file:

> command = "cd #{@path} && zip --symlinks -rq #{zip_file} ."

to:

> command` = "cd #{@path} && **chmod -R 755 .** && zip --symlinks -rq #{zip_file} ."

## How to Test

	You shall create a custom layer with the following structure:

		.
		|_lib
		|_ruby
		  |_gems
		    |_2.7.0
		      |_**
        
	After that, try adding the custom layer on the lambda.


## Version Changes

	3.0.3

I hope you consider this PR as a possible solution for this problem. 

Best regards