### PR TITLE
2.3.x gem detection

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv"
   spec.add_dependency "gems" # jets-gems dependency
   spec.add_dependency "hashie"
-  spec.add_dependency "jets-gems"
+  spec.add_dependency "jets-gems", "~> 0.2.3"
   spec.add_dependency "jets-html-sanitizer"
   spec.add_dependency "kramdown"
   spec.add_dependency "memoist"

--- a/lib/jets/builders/gem_replacer.rb
+++ b/lib/jets/builders/gem_replacer.rb
@@ -21,9 +21,21 @@ module Jets::Builders
         options = @options.merge(source_url: source)
         gem_extractor = Jets::Gems::Extract::Gem.new(gem_name, options)
         gem_extractor.run
+        rename_gem(gem_name)
       end
 
       tidy
+    end
+
+    def rename_gem(gem_name)
+      ruby_folder = "#{Jets.build_root}/stage/opt/ruby/gems/#{Jets::Gems.ruby_folder}"
+      gems_folder = "#{ruby_folder}/gems"
+      expr = "#{gems_folder}/#{gem_name}-x*-{darwin,linux}"
+      src = Dir.glob(expr).first
+      return unless src
+
+      dest = src.sub("-darwin", "-linux")
+      FileUtils.mv(src, dest) unless File.exist?(dest) # looks like rename_gem actually runs twice
     end
 
     def sh(command)


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Handled this in Jets v3. Thought this was a ruby 2.7 vs ruby 2.5 issue but it's more specific than that. It's has to do with specifically how some gems like nokogiri now maybe bundles. Anyway, backported this fix.

## Context

#523 #524 

https://github.com/boltops-tools/serverlessgems/pull/1

## How to Test

Deploy Jets app that uses the nokogiri gem.

## Version Changes

Patch