### PR TITLE
use mini_mime instead

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jets-html-sanitizer"
   spec.add_dependency "kramdown"
   spec.add_dependency "memoist"
-  spec.add_dependency "mimemagic"
+  spec.add_dependency "mini_mime"
   spec.add_dependency "rack"
   spec.add_dependency "railties", "~> 6.1.0" # for ActiveRecord database_tasks.rb
   spec.add_dependency "rainbow"

--- a/lib/jets/internal/app/controllers/jets/public_controller.rb
+++ b/lib/jets/internal/app/controllers/jets/public_controller.rb
@@ -1,5 +1,5 @@
 require "rack/mime"
-require "mimemagic"
+require "mini_mime"
 
 class Jets::PublicController < Jets::Controller::Base
   layout false
@@ -12,7 +12,7 @@ class Jets::PublicController < Jets::Controller::Base
 
     if File.exist?(catchall_path)
       content_type = Rack::Mime.mime_type(File.extname(catchall_path))
-      binary = !MimeMagic.by_path(catchall_path).text?
+      binary = !MiniMime.lookup_by_filename(catchall_path).content_type.include?("text")
 
       # For binary support to work, the client also has to send the right Accept header.
       # And the media type has been to added to api gateway.


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Use mini_mime gem instead

## Context

closes #535

## How to Test

Regression: Deploy jets app and make sure it still works. 

## Version Changes

Patch