### PR TITLE
Add instructions for aws-cli prerequisite

### DIFF
--- a/docs/_docs/extras/minimal-deploy-iam.md
+++ b/docs/_docs/extras/minimal-deploy-iam.md
@@ -50,7 +50,7 @@ Here's a summary of the commands:
     }
     EOF
     aws iam put-group-policy --group-name Jets --policy-name JetsPolicy --policy-document file:///tmp/jets-iam-policy.json
-    
+
 If your environment requires a "least privilege" approach, these commands will create a policy that has been reported to work well:
 
     aws iam create-group --group-name Jets
@@ -168,6 +168,23 @@ Finally, create a user and add the user to IAM group. Here's an example:
 
     aws iam create-user --user-name tung
     aws iam add-user-to-group --user-name tung --group-name Jets
+
+## Alternately create policy, group, and user in AWS console
+
+The above steps can alternately be created in AWS Console.
+
+Go to [IAM Policies](https://console.aws.amazon.com/iam/home?nc2=h_m_sc#/policies).
+Click "Create policy", then "JSON", then "Next: tags", then "Next: review".
+Name the policy "JetsPolicy" and click "Create policy".
+
+Go to [IAM Groups](https://console.aws.amazon.com/iam/home?nc2=h_m_sc#/groups).
+Click "Create new group". Name the group "Jets" and click "Next step".
+Search for "JetsPolicy", check its checkbox, click "Next step", then "Create group".
+
+Go to [IAM Users](https://console.aws.amazon.com/iam/home?nc2=h_m_sc#/users).
+Click "Add user". Give the user a name and check "Programmatic access".
+Click "Next: permissions". Check the "Jets" group to add user to group.
+Click "Next: tags", "Next: Review", then "Create user".
 
 ## Additional IAM Permissions
 

--- a/docs/_docs/install.md
+++ b/docs/_docs/install.md
@@ -12,9 +12,34 @@ Install jets via RubyGems.
 
 Jets works on macosx and linux variants. Jets does not work on windows.  For windows, recommend considering [Cloud9 IDE](https://aws.amazon.com/cloud9/). There are some nice advantages like [Faster Development](https://rubyonjets.com/docs/faster-development/).
 
+### IAM policy, group, and user
+
+The IAM user you use to run the `jets deploy` command
+needs a minimal set of IAM policies in order to deploy a Jets application.
+Follow the [Minimal Deploy Policy IAM Policy](/docs/extras/minimal-deploy-iam)
+to create the policy, group, and user.
+
+Use the user's credentials to configure the `aws-cli` below.
+
+### aws-cli
+
+Install the [aws-cli](https://aws.amazon.com/cli/) using your method of choice.
+For example, with Homebrew on macOS:
+
+    brew install awscli
+
+Configure it:
+
+    aws configure
+
+Use the user's Access Key ID and Secret Access Key from the IAM steps above.
+
 ### Ruby
 
-Jets supports Ruby 2.5 and Ruby 2.7. Patch variants of it should work. More details: [Using Different Ruby Versions]({% link _docs/extras/ruby-versions.md %}).
+Jets supports Ruby 2.5 and Ruby 2.7,
+which are the Ruby versions supported by AWS Lambda.
+Patch variants of it should work.
+More details: [Using Different Ruby Versions]({% link _docs/extras/ruby-versions.md %}).
 
 ### Yarn
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,27 +4,9 @@ title: Quick Start
 
 In a hurry? No problem!  Here's a quick start to get going.
 
-## Prerequisites
-
-If you don't already have the [aws-cli](https://aws.amazon.com/cli/) installed,
-install it using your method of choice. For example, Homebrew on macOS:
-
-    brew install awscli
-
-Ensure it is also configured:
-
-    aws configure
-
-It will ask for an Access Key ID and Secret Access Key.
-Go to the [IAM within AWS Console](https://console.aws.amazon.com/iam)
-and either use your root
-[security credentials](https://console.aws.amazon.com/iam/home#/security_credentials)
-or create a user with the following permissions: TODO.
-
 ## Local Testing
 
-Jets requires the Ruby versions supported by AWS Lambda.
-Currently, that is Ruby 2.7. Set your Ruby environment to 2.7. Then:
+Review prerequisites on the [Install](/docs/install) page. Then:
 
     gem install jets
     jets new demo

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,27 @@ title: Quick Start
 
 In a hurry? No problem!  Here's a quick start to get going.
 
+## Prerequisites
+
+If you don't already have the [aws-cli](https://aws.amazon.com/cli/) installed,
+install it using your method of choice. For example, Homebrew on macOS:
+
+    brew install awscli
+
+Ensure it is also configured:
+
+    aws configure
+
+It will ask for an Access Key ID and Secret Access Key.
+Go to the [IAM within AWS Console](https://console.aws.amazon.com/iam)
+and either use your root
+[security credentials](https://console.aws.amazon.com/iam/home#/security_credentials)
+or create a user with the following permissions: TODO.
+
 ## Local Testing
+
+Jets requires the Ruby versions supported by AWS Lambda.
+Currently, that is Ruby 2.7. Set your Ruby environment to 2.7. Then:
 
     gem install jets
     jets new demo


### PR DESCRIPTION
I was tripped up when running through the Quick Start in this way:

* I went to the Quick Start page.
* I started running the commands.

My issues were:

* I was running Ruby 3, which installed an old, pre-v1 version of `jets`.
* I had not configured the `aws` CLI so `jets deploy` failed.

This pull request edits the docs to help avoid this mistakes by:

* Noting that there are prerequisites and linking to the Install section for more details.
* Referencing the IAM policy page before `aws-cli` install instructions
  so that the reader creates the policy, group, and user before configuring CLI.