### PR TITLE
FIX DEPRECATION WARNING: connection_config is deprecated

### DIFF
--- a/lib/jets/overrides/rails/migration_checker.rb
+++ b/lib/jets/overrides/rails/migration_checker.rb
@@ -1,11 +1,15 @@
 module ActiveRecord
   module MigrationChecker
     def prepare_test_db
-      current_config = ::ActiveRecord::Base.connection_config
+      current_config = ::ActiveRecord::Base.connection_db_config
       all_configs = ::ActiveRecord::Base.configurations.configs_for(env_name: Jets.env)
 
       needs_update = !all_configs.all? do |db_config|
-        ::ActiveRecord::Tasks::DatabaseTasks.schema_up_to_date?(db_config.config, ::ActiveRecord::Base.schema_format, nil, Jets.env, db_config.spec_name)
+        ::ActiveRecord::Tasks::DatabaseTasks.schema_up_to_date?(
+          db_config.configuration_hash, 
+          ::ActiveRecord::Base.schema_format, 
+          nil
+        )
       end
 
       if needs_update


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
this pr fixes the following deprecations warnings

- [x] DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead) (called from <top (required)> at /Users/jdaviderb/jets/test/spec/spec_helper.rb:13)
- [x] DEPRECATION WARNING: DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys (called from <top (required)> at /Users/jdaviderb/jets/test/spec/spec_helper.rb:13)
- [x] DEPRECATION WARNING: `environment` and `name` will be removed as parameters in 6.2.0, you may now pass an ActiveRecord::DatabaseConfigurations::DatabaseConfig as `configuration` instead. (called from <top (required)> at /Users/jdaviderb/jets/test/spec/spec_helper.rb:13)


<!--
Provide a description of what your pull request changes.
-->

## Context

ref
https://github.com/boltops-tools/jets/issues/538

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

