### PR TITLE
doesn't include the Jets layer when config.gems.disabled = true

### DIFF
--- a/lib/jets/resource/lambda/function.rb
+++ b/lib/jets/resource/lambda/function.rb
@@ -136,6 +136,8 @@ module Jets::Resource::Lambda
 
     def get_layers(runtime)
       return nil unless runtime =~ /^ruby/
+      return Jets.config.lambda.layers if Jets.config.gems.disable
+      
       ["!Ref GemLayer"] + Jets.config.lambda.layers
     end
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
We have an enterprise app running on jets but we have a custom layer for this application, when we try to add our custom layer the deployments fail because it exceeds the layer limit on lambda, I did a quick research and I realized that when I add a custom layer, Jets stills uploading its layer.


<!--
Provide a description of what your pull request changes.
-->

## Context
ref https://github.com/boltops-tools/jets/issues/541

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

