### PR TITLE
Handle Errors::InvalidClientTokenId when get_caller_identity fails

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -55,7 +55,7 @@ module Jets
       ENV['AWS_REGION'] ||= region
       begin
         sts.get_caller_identity.account
-      rescue Aws::Errors::MissingCredentialsError, Aws::Errors::NoSuchEndpointError
+      rescue Aws::Errors::MissingCredentialsError, Aws::Errors::NoSuchEndpointError, Aws::STS::Errors::InvalidClientTokenId
         puts "INFO: You're missing AWS credentials. Only local services are currently available"
       rescue Seahorse::Client::NetworkingError
         puts "INFO: No internet connection available. Only local services are currently available"


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix. 
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This PR catches `Aws::STS::Errors::InvalidClientTokenId` thrown in `aws_info.rb` when attempting to `get_caller_identity`.

<!--
Provide a description of what your pull request changes.
-->

## Context

From a clean install of `jets` on my machine, I followed the instructions but was unable to run `jets db:create` after using the `--database=postgresql` and `--mode api` options to setup a new jets app.

After testing locally, I am able to run both `jets db:create` and `jets server` with this change.

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

Remove `~/.aws/credentials` and run `jets new test_app --mode api --database=postgresql`.  After bundling, you should be able to run `jets db:create` and `jets server` successfully.

## Version Changes

Bump to `3.0.6`
<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

