### PR TITLE
Use description specified in function properties exactly

### DIFF
--- a/lib/jets/resource/lambda/function.rb
+++ b/lib/jets/resource/lambda/function.rb
@@ -123,6 +123,7 @@ module Jets::Resource::Lambda
     def finalize_properties!(props)
       handler = full_handler(props)
       runtime = get_runtime(props)
+      description = get_descripton(props)
       managed = {
         handler: handler,
         runtime: runtime,
@@ -204,7 +205,11 @@ module Jets::Resource::Lambda
       function_name.size > Jets::MAX_FUNCTION_NAME_SIZE ? nil : function_name
     end
 
-    def description
+    def get_descripton(props)
+      props[:description] || default_description
+    end
+      
+    def default_description
       # Example values:
       #   @app_class: Admin/PagesController
       #   @task.meth: index

--- a/spec/fixtures/apps/franky/app/controllers/articles_controller.rb
+++ b/spec/fixtures/apps/franky/app/controllers/articles_controller.rb
@@ -2,6 +2,7 @@ class ArticlesController < ApplicationController
   before_action :set_article, only: [:show, :edit, :update, :delete]
 
   # GET /articles
+  description "All articles"
   def index
     @articles = Article.all
   end

--- a/spec/lib/jets/resource/lambda/function_spec.rb
+++ b/spec/lib/jets/resource/lambda/function_spec.rb
@@ -14,6 +14,18 @@ describe Jets::Resource::Lambda::Function do
     end
   end
 
+  context "function with description specified" do
+    let(:task) do
+      ArticlesController.all_public_tasks[:index]
+    end
+    it "uses function properties" do
+      expect(resource.logical_id).to eq "IndexLambdaFunction"
+      properties = resource.properties
+      # puts YAML.dump(properties) # uncomment to debug
+      expect(properties["Description"]).to eq "All articles"
+    end
+  end
+
   context "controller" do
     let(:task) do
       PostsController.all_public_tasks[:index]


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Jets allows us to specify a description as a function property, but even if we do, it will not be reflected in the Lambda function and the default description will be used(e.g. `PostsController#index`).
It seems that the specified description is overwritten with the default description when creating the CloudFormation template.
So, I propose to modify behavior to use specified description if there is.

## Context
None

## How to Test

1. Reflect the changes contained in this PR in your local Jets gem.
2. Clone the demo app from my repo. This app has only one controller and only one action is defined, with a description for that action.
    - Run `$ git clone git@github.com:kfukai23/demo.git`
3. Run `$ jets deploy`.
4. Open the list of Lambda functions in the AWS console and verify that the description of the created Lambda function is the one specified in the demo app.

<details>
  <summary>An example of a CloudFormation template created when I run the above</summary>
  
  ### Template before gem modification
<img width="700" alt="スクリーンショット_2021-04-26_21_32_07" src="https://user-images.githubusercontent.com/36021748/116091093-7bcecb80-a6df-11eb-8a59-0edb85fbbf3d.png">
  


  ### Template after gem modification
<img width="700" alt="スクリーンショット_2021-04-26_21_37_09" src="https://user-images.githubusercontent.com/36021748/116091038-6fe30980-a6df-11eb-9628-35d2363cb193.png">

  
  
</details>