### PR TITLE
fix routing for mounted rack apps in local environments

### DIFF
--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -13,7 +13,11 @@ module Jets::Controller::Rack
       options = {}
       options = add_top_level(options)
       options = add_http_headers(options)
-      path = path_with_base_path || @event['path'] || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
+      path = if Jets.env.development? || Jets.env.test?
+        @event['path']
+      else
+        path_with_base_path || '/' # always set by API Gateway but might not be when testing shim, so setting it to make testing easier
+      end
 
       env = Rack::MockRequest.env_for(path, options)
       if @options[:adapter]
@@ -27,7 +31,7 @@ module Jets::Controller::Rack
     def path_with_base_path
       resource = @event['resource']
       pathParameters = @event['pathParameters']
-      
+
       if(!pathParameters.nil? and !resource.nil?)
         resource = pathParameters.reduce(resource) {|resource, parameter|
           key, value = parameter

--- a/spec/fixtures/dumps/api_gateway/books/list.json
+++ b/spec/fixtures/dumps/api_gateway/books/list.json
@@ -1,5 +1,5 @@
 {
-  "resource": "/books/list",
+  "resource": "/books/{path+}",
   "path": "/books/list",
   "httpMethod": "GET",
   "headers": {


### PR DESCRIPTION
This is a 🐞 bug fix.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Updated `Jets::Controller::Rack::Env#convert` to use `@event['path']` if running on local environment. `path_with_base_path` returns a path for API Gateway.

## Context

https://github.com/boltops-tools/jets/issues/548

## How to Test

1. Checkout https://github.com/boltops-tools/jets-routes-mount
2. Point to this branch in the bundle file
3. Navigate to any nested route for a mounted rack app

See https://github.com/boltops-tools/jets/issues/548 for more details


## Version Changes


