### PR TITLE
fix content-type case

### DIFF
--- a/lib/jets/controller/rack/env.rb
+++ b/lib/jets/controller/rack/env.rb
@@ -64,7 +64,7 @@ module Jets::Controller::Rack
     end
 
     def content_type
-      headers['Content-Type'] || Jets::Controller::DEFAULT_CONTENT_TYPE
+      headers['content-type'] || Jets::Controller::DEFAULT_CONTENT_TYPE
     end
 
     def content_length

--- a/spec/fixtures/dumps/api_gateway/books/list.json
+++ b/spec/fixtures/dumps/api_gateway/books/list.json
@@ -12,7 +12,7 @@
     "CloudFront-Is-SmartTV-Viewer": "false",
     "CloudFront-Is-Tablet-Viewer": "false",
     "CloudFront-Viewer-Country": "US",
-    "Content-Type": "text/plain",
+    "content-type": "text/plain",
     "Host": "uhghn8z6t1.execute-api.us-east-1.amazonaws.com",
     "Postman-Token": "7166b11b-59de-4e7b-ad35-24e556b7a083",
     "User-Agent": "PostmanRuntime/6.4.1",

--- a/spec/lib/jets/controller/rack/env_spec.rb
+++ b/spec/lib/jets/controller/rack/env_spec.rb
@@ -15,6 +15,7 @@ describe Jets::Controller::Rack::Env do
       expect(env['REMOTE_ADDR']).to eq("69.42.1.180, 54.239.203.100")
       expect(env['REQUEST_URI']).to eq("https://uhghn8z6t1.execute-api.us-east-1.amazonaws.com/books/list?a=1&b=2")
       expect(env['HTTP_USER_AGENT']).to eq("PostmanRuntime/6.4.1")
+      expect(env['CONTENT_TYPE']).to eq("text/plain")
       expect(env["rack.input"]).not_to be nil
     end
   end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
Changed `headers['Content-Type']` to lowercase `headers['content-type']` in `lib/jets/controller/rack/env.rb`

## Context
By the time the `Content-Type` header reaches `lib/jets/controller/rack/env.rb`, it is always converted to lower case which will always result in the type being `Jets::Controller::DEFAULT_CONTENT_TYPE`

## How to Test
Mount any rack app and do a json request. The content type will be `Jets::Controller::DEFAULT_CONTENT_TYPE` when it reaches the mounted app.


------------------------------
I considered converted all headers to lowercase in the file but I'm not sure what unintended side effects it would have since I'm familiar with the codebase.