### PR TITLE
add pure ruby implementation of compute_size

### DIFF
--- a/lib/jets/builders/code_size.rb
+++ b/lib/jets/builders/code_size.rb
@@ -40,9 +40,15 @@ module Jets::Builders
     end
 
     def compute_size(path)
-      # -k option is required for macosx but not for linux
-      out = `du -ks #{path}`
-      out.split(' ').first.to_i # bytes
+      total_bytes = 0
+      Dir.each_child(path) do |entry|
+        child_path = File.join(path, entry)
+        next unless File.exist?(child_path)
+        total_bytes += File.lstat(child_path).size
+        next if File.symlink?(child_path)
+        total_bytes += compute_size(child_path) if File.directory?(child_path)
+      end
+      total_bytes
     end
 
     def megabytes(bytes)

--- a/lib/jets/builders/code_size.rb
+++ b/lib/jets/builders/code_size.rb
@@ -48,7 +48,7 @@ module Jets::Builders
         next if File.symlink?(child_path)
         total_bytes += compute_size(child_path) if File.directory?(child_path)
       end
-      total_bytes
+      total_bytes / 1024
     end
 
     def megabytes(bytes)


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* adds pure Ruby implementation for `compute_size`
* this implementation does not follow symlinks, but will include
  the size of the symlink itself when calculating total size

## Context

* Fixes #571
* Behavior originally noticed in #561 

## How to Test

Run a deploy. To confirm it fixes #571, you need to run the deploy in GitHub Actions as outlined in the issue.


## Version Changes

Minor version bump


