### PR TITLE
exclude code/vendor/bundle from deploy stage if it exists

### DIFF
--- a/lib/jets/builders/lambda_layer.rb
+++ b/lib/jets/builders/lambda_layer.rb
@@ -8,6 +8,10 @@ module Jets::Builders
     def build
       consolidate_gems_to_opt
       replace_compiled_gems unless Jets.config.gems.disable
+
+      # we need to delete this directory if it exists
+      bundle_path = "#{stage_area}/code/vendor/bundle"
+      FileUtils.rm_rf(bundle_path) if Dir.exist?(bundle_path)
     end
 
     # Also restructure the folder from:


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This is a confirmed fix for #571. We are already using my fork with this patch at our company until this or an equivalent fix is merged.

Note @tongueroo if you want to make some edits, I'd be happy to try them out on our CI and see if your modified version still fixes the issue.

## Context

In some environments (such as docker, apparently), an extra `/tmp/jets/[project]/stage/code/vendor/bundle` directory appears that should not be included in the deployment. When it is included the deploy typically fails because we will exceed the maximum lambda code size of 250 MB.

## How to Test

Run `jets deploy` on a project within an affected system. The sample GitHub Action config in #571 should work fine for testing this.


## Version Changes

Minor version bump

