### PR TITLE
fix missing webpacker helpers

### DIFF
--- a/lib/jets/core.rb
+++ b/lib/jets/core.rb
@@ -43,7 +43,7 @@ module Jets::Core
   memoize :logger
 
   def webpacker?
-    Gem.loaded_specs.keys.include?("webpacker")
+    Gem.loaded_specs.keys.any?{|k| k.start_with?("webpacker")}
   end
   memoize :webpacker?
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix. 
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
I'm not sure why this changed, but after a dependency update my HTML rendering pages failed because the webpacker helpers were not available in ActionView::Base. This fixed the issue.
<!--
Provide a description of what your pull request changes.
-->

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

