### PR TITLE
Fixes API Gateway base path Lambda not respecting various config opts

### DIFF
--- a/lib/jets/resource/api_gateway/base_path/function.rb
+++ b/lib/jets/resource/api_gateway/base_path/function.rb
@@ -25,7 +25,9 @@ module Jets::Resource::ApiGateway::BasePath
     end
 
     def layers
-      ["!Ref GemLayer"]
+      return Jets.config.lambda.layers if Jets.config.gems.disable
+
+      ["!Ref GemLayer"] + Jets.config.lambda.layers
     end
 
     def function_name


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

This PR resolves two bugs when using a custom domain for API Gateway:

-  Any custom lambda layers used would be ignored
- if `config.gems.disable = true`, continue to use `config.lambda.layers`.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

Stumbled upon this one when trying to use a custom domain for API gateway via `config.domain.*` but it was perpetually failing as `JETS_AGREE=no` and `config.gems.disable = true`, meaning it was trying to use an incomplete layer (the default Jets layer) as opposed to a custom provided layer. 

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->

1. Prepare a lambda layer that _isn't_ namespaced by Jets.
     - For brevity + speed sake you can generate the lambda layer via the serverlessgems.com service, download and then re-upload under a new name. Key thing here is the arn isn't the one prepared by Jets
2. Configure `config.gems.disable = true` and `config.lambda.layers` with your custom arn. 
3. Configure the `config.domain.*` options.
4. `jets deploy`
5. Watch it succeed!

The layer arn listed in the lambda `<project-name>-jets-base-path-<timestamp>` should be your custom layer as opposed to the default and will allow for Cloudformation to correctly deploy. 

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

Recommend bumping PATCH (e.g. 3.0.10) as this is a backwards-compatible fix (no impact for developers using the default logic). 



