### PR TITLE
Jetsignore

### DIFF
--- a/docs/_docs/extras/jetsignore.md
+++ b/docs/_docs/extras/jetsignore.md
@@ -1,0 +1,27 @@
+---
+title: Jetsignore
+---
+
+## .jetsignore
+
+To keep the Lambda zip file size down, you might want to avoid packaging up large folders. You can do this with the `.jetsignore` file.  Example:
+
+.jetsignore
+
+    some/large/folder
+    vendor/bundle
+
+This tells Jets not to package up `some/large/folder` and `vendor/bundle`.
+
+## .jetskeep
+
+There's also a `.jetskeep` file concept. The default values for this is:
+
+    .bundle
+    /public/packs
+    /public/packs-test
+    vendor
+
+This file tells Jets to keep these files regardless of what's configured with `.jetsignore`. So the `.jetskeep` has higher precedence than `.jetsignore`.
+
+Note: If you create a `.jetskeep` file, it will override the defaults entirely.

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -133,6 +133,7 @@
               <li><a href="{% link _docs/extras/minimal-deploy-iam/console.md %}">Console</a></li>
             </ul>
           </li>
+          <li><a href="{% link _docs/extras/jetsignore.md %}">Jetsignore</a></li>
           <li><a href="{% link _docs/extras/custom-inflections.md %}">Custom Inflections</a></li>
           <li><a href="{% link _docs/extras/config-rules.md %}">Config Rules</a></li>
           <li><a href="{% link _docs/extras/gem-layer.md %}">Gem Layer</a></li>

--- a/lib/jets/builders/tidy.rb
+++ b/lib/jets/builders/tidy.rb
@@ -38,7 +38,7 @@ module Jets::Builders
       removals += get_removals("#{@project_root}/.jetsignore")
       removals = removals.reject do |p|
         jetskeep.find do |keep|
-          p.include?(keep)
+          p == keep
         end
       end
       removals.uniq
@@ -56,7 +56,7 @@ module Jets::Builders
     # We clean out ignored files pretty aggressively. So provide
     # a way for users to keep files from being cleaned out.
     def jetskeep
-      always = %w[.bundle packs vendor]
+      always = %w[.bundle /public/packs /public/packs-test vendor]
       path = "#{@project_root}/.jetskeep"
       return always unless File.exist?(path)
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adjust default `.jetskeep` handling to allow ignoring files like `vendor/bundle`. This helps to keep the zipfile size down.

## Context

* #571 In some environments, a /tmp/jets/[project]/stage/vendor/bundle directory remains and is included in zip, causing deploys to fail
* #573 exclude code/vendor/bundle from deploy stage if it exists 

## How to Test

1. Create a `.jetsignore`
2. Add files to it
3. Deploy and confirm that the files are not part of the Lambda zipfile package. You can do this by looking at the Lambda console and looking at the file tree.

## Version Changes

Patch