### PR TITLE
Update "jets delete" documentation to be --yes instead of --skip

### DIFF
--- a/docs/_reference/jets-delete.md
+++ b/docs/_reference/jets-delete.md
@@ -30,14 +30,14 @@ This deletes the all the contents in the internal s3 bucket that jets uses and t
     Project demo-dev deleted!
     $
 
-You can bypass the are you sure prompt with the `--sure` flag.
+You can bypass the are you sure prompt with the `--yes` flag.
 
-    $ jets delete --sure
+    $ jets delete --yes
 
 ## Options
 
 ```
-[--sure], [--no-sure]  # Skip are you sure prompt.
+[--yes],               # Skip are you sure prompt.
 [--wait], [--no-wait]  # Wait for stack deletion to complete.
                        # Default: true
 [--noop], [--no-noop]  

--- a/lib/jets/commands/help/delete.md
+++ b/lib/jets/commands/help/delete.md
@@ -17,6 +17,6 @@ This deletes the all the contents in the internal s3 bucket that jets uses and t
     Project demo-dev deleted!
     $
 
-You can bypass the are you sure prompt with the `--sure` flag.
+You can bypass the are you sure prompt with the `--yes` flag.
 
-    $ jets delete --sure
+    $ jets delete --yes


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change. 

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [X] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

## Context

Updates the documentation for `jets delete`. The documentation shows that you should be able to skip the prompt with `--skip` but the code shows that this is actually `--yes`

https://github.com/boltops-tools/jets/blob/35bb5a40148074ae03f03b85b16e63707df90970/lib/jets/commands/delete.rb#L116-L122

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

N/A

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->

