### PR TITLE
Use active support instead of actionview

### DIFF
--- a/lib/jets/builders/md5_zip.rb
+++ b/lib/jets/builders/md5_zip.rb
@@ -1,4 +1,4 @@
-require 'action_view'
+require "active_support/number_helper"
 
 # Examples:
 #
@@ -10,7 +10,7 @@ require 'action_view'
 #
 module Jets::Builders
   class Md5Zip
-    include ActionView::Helpers::NumberHelper # number_to_human_size
+    include ActiveSupport::NumberHelper # number_to_human_size
     include Util
 
     def initialize(folder)

--- a/spec/lib/jets/builders/md5_zip_spec.rb
+++ b/spec/lib/jets/builders/md5_zip_spec.rb
@@ -1,0 +1,19 @@
+require "active_support/number_helper"
+
+describe Jets::Builders::Md5Zip do
+  include ActiveSupport::NumberHelper
+
+  let(:instance) { described_class.new(folder) }
+  let(:folder) { 'test-folder' }
+
+  describe 'initialize' do
+    it { expect(instance.instance_variable_get(:@path)).to eq("#{Jets.build_root}/#{folder}") }
+  end
+
+  describe '#number_to_human_size' do
+    it 'converts file size to human readable number' do
+      file_size = 25000
+      expect(instance.send(:number_to_human_size, file_size)).to eq(number_to_human_size(file_size))
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

NumberHelper has been moved to active support from actionview. this is sometimes causing jets builds to fail.

## Context
https://github.com/boltops-tools/jets/issues/579

## How to Test

Run `jets build` 
