### PR TITLE
use Shotgun::Static middleware always

### DIFF
--- a/lib/jets/middleware/default_stack.rb
+++ b/lib/jets/middleware/default_stack.rb
@@ -1,3 +1,5 @@
+require "shotgun"
+
 module Jets::Middleware
   class DefaultStack
     attr_reader :config, :app
@@ -8,7 +10,7 @@ module Jets::Middleware
 
     def build_stack
       Stack.new do |middleware|
-        middleware.use Shotgun::Static if Jets.env.development?
+        middleware.use Shotgun::Static
         middleware.use Rack::Runtime
         middleware.use Jets::Controller::Middleware::Cors if cors_enabled?
         middleware.use Rack::MethodOverride # must come before Middleware::Local for multipart post forms to work

--- a/spec/lib/jets/middleware/stack_spec.rb
+++ b/spec/lib/jets/middleware/stack_spec.rb
@@ -5,7 +5,7 @@ describe Jets::Middleware::Stack do
       endpoint = Jets::Controller::Middleware::Main
       middleware = default_stack.build(endpoint) # uncomment to see middleware tree
       # pp middleware # uncomment to see and debug
-      expect(middleware).to be_a Rack::Runtime # top of the tree
+      expect(middleware).to be_a Shotgun::Static # top of the tree
       # $ jets middleware
       # use Rack::Runtime
       # use Rack::MethodOverride


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Always use Shotgun::Static middleware. This allows static assets and images to be service in JETS_ENV=test mode.

## Version Changes

Patch