### PR TITLE
Don't overwrite content_type  when rendering json or xml with content_type specified

### DIFF
--- a/lib/jets/controller/rendering.rb
+++ b/lib/jets/controller/rendering.rb
@@ -33,6 +33,8 @@ class Jets::Controller
     end
 
     def adjust_content_type!(options)
+      return if options.key?(:content_type)
+
       if options.key?(:json)
         options[:content_type] = "application/json"
       elsif options.key?(:xml)

--- a/spec/lib/jets/controller/rendering_spec.rb
+++ b/spec/lib/jets/controller/rendering_spec.rb
@@ -29,6 +29,13 @@ describe Jets::Controller::Base do
     it "render json" do
       status, headers, body = controller.render(json: {my: "data"})
       expect(body).to respond_to(:each)
+      expect(headers["Content-Type"]).to eq "application/json"
+    end
+
+    it "render json with content-type" do
+      status, headers, body = controller.render(json: {my: "data"}, content_type: "application/json;charset=UTF-8")
+      expect(body).to respond_to(:each)
+      expect(headers["Content-Type"]).to eq "application/json;charset=UTF-8"
     end
 
     it "render file" do


### PR DESCRIPTION
This is a 🐞 bug fix.

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Don't overwrite `content_type` when rendering json or xml with `content_type` specified.

example:

```ruby
render json: {my: "data"}, content_type: "application/json;charset=UTF-8"
# => Content-Type is overwritten with "application/json"
```

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->
None

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->

```ruby
render json: {my: "data"}, content_type: "application/json;charset=UTF-8"
# => Content-Type remains "application/json;charset=UTF-8"
```


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

