### PR TITLE
Adds an override flag to change behaviour when Jets is behind an ELB running Jets Server

### DIFF
--- a/docs/_docs/extras/elb-server-override.md
+++ b/docs/_docs/extras/elb-server-override.md
@@ -1,0 +1,11 @@
+---
+title: ELB Server Override Flag for jets server
+---
+
+## Background
+
+While the goal of Jets is to create and deploy serverless services, there is often a need to run Jets in the server mode to debug your applications. 
+This may include hosting it on AWS and having it reachable through a load balancer such as an Application Load Balancer. 
+
+
+In the event you have a need to run it through an Elastic Load Balancer while running `jets server`, setting `JETS_SERVER_ELB_OVERRIDE` to `1` will guarantee `jets server` behaviour even when behind an ELB. 

--- a/lib/jets/controller/middleware/local.rb
+++ b/lib/jets/controller/middleware/local.rb
@@ -70,7 +70,7 @@ module Jets::Controller::Middleware
 
     def on_aws?(env)
       return false if Jets.env.test? # usually with test we're passing in full API Gateway fixtures with the HTTP_X_AMZN_TRACE_ID
-      return false if ENV['JETS_SERVER_ALB_OVERRIDE'] # If we're using an ALB and Jets is inside a container running jets server, we don't want to pretend we're on AWS.
+      return false if ENV['JETS_SERVER_ELB_OVERRIDE'] # If we're using an ALB and Jets is inside a container running jets server, we don't want to pretend we're on AWS.
       on_cloud9 = !!(env['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
       !!env['HTTP_X_AMZN_TRACE_ID'] && !on_cloud9
     end

--- a/lib/jets/controller/middleware/local.rb
+++ b/lib/jets/controller/middleware/local.rb
@@ -70,7 +70,7 @@ module Jets::Controller::Middleware
 
     def on_aws?(env)
       return false if Jets.env.test? # usually with test we're passing in full API Gateway fixtures with the HTTP_X_AMZN_TRACE_ID
-      return false if ENV['JETS_SERVER_ELB_OVERRIDE'] # If we're using an ALB and Jets is inside a container running jets server, we don't want to pretend we're on AWS.
+      return false if ENV['JETS_SERVER_ELB_OVERRIDE'] # If we're using an ELB and Jets is inside a container running jets server, we don't want to pretend we're on AWS.
       on_cloud9 = !!(env['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
       !!env['HTTP_X_AMZN_TRACE_ID'] && !on_cloud9
     end

--- a/lib/jets/controller/middleware/local.rb
+++ b/lib/jets/controller/middleware/local.rb
@@ -70,6 +70,7 @@ module Jets::Controller::Middleware
 
     def on_aws?(env)
       return false if Jets.env.test? # usually with test we're passing in full API Gateway fixtures with the HTTP_X_AMZN_TRACE_ID
+      return false if ENV['JETS_SERVER_ALB_OVERRIDE'] # If we're using an ALB and Jets is inside a container running jets server, we don't want to pretend we're on AWS.
       on_cloud9 = !!(env['HTTP_HOST'] =~ /cloud9\..*\.amazonaws\.com/)
       !!env['HTTP_X_AMZN_TRACE_ID'] && !on_cloud9
     end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix.  -->
- This is a 🙋‍♂️ feature or enhancement.
- This is a 🧐 documentation change. 

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [X] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This PR adds an override flag (`JETS_SERVER_ELB_OVERRIDE`) so if `jets server` is being fed traffic through an ELB, we get the same behaviour as if we were hitting it locally or through another load balancer.

## Context

As part of some internal work going on where I work, there's been a need to create a stronger feedback loop with a copy of various services, including one that uses Jets. These services can be fed through an ELB (typically an ALB) and will generally work as they would as if in a production environment however, Jets appears to diverge in its behaviour if we're behind an ELB - 

https://github.com/boltops-tools/jets/blob/1ccd80b49d22bfdd53fa22f998b6faae37d8fe33/lib/jets/controller/middleware/local.rb#L71-L74

Returning `false` here resolves the issue and gets our intended behaviour. Unfortunately, I don't have enough context as to why this is being done and I don't want to risk potentially breaking anyone that might be using behaviour around this so I've added it in as a flag instead. 

I'm not a Ruby developer by trade so please feel free to give pointers if there's a better way!

## How to Test

Set up Jets to work behind an ELB and running in `jets server`. Without `JETS_SERVER_ELB_OVERRIDE` you'll get a 500 error (as well as a stack trace if you're running in a debug mode). `JETS_SERVER_ELB_OVERRIDE` being set to any value (recommendation `1`) will override this logic and have it functioning as intended. 


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

A patch bump (e.g. `3.0.14`) is recommended for a bump in version. 