### PR TITLE
custom domain: adjust rate limit for base mapping

### DIFF
--- a/lib/jets/internal/app/functions/jets/base_path_mapping.rb
+++ b/lib/jets/internal/app/functions/jets/base_path_mapping.rb
@@ -4,6 +4,25 @@ require 'aws-sdk-cloudformation'
 class BasePathMapping
   def initialize(event, stage_name)
     @event, @stage_name = event, stage_name
+    aws_config_update!
+  end
+
+  # Override the AWS retry settings. The aws-sdk-core has expondential backup with this formula:
+  #
+  #   2 ** c.retries * c.config.retry_base_delay
+  #
+  # So the max delay will be 2 ** 7 * 0.6 = 76.8s
+  #
+  # Useful links:
+  #
+  #   https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+  #   https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+  #
+  def aws_config_update!
+    Aws.config.update(
+      retry_limit: 7, # default: 3
+      retry_base_delay: 0.6, # default: 0.3
+    )
   end
 
   # Cannot use update_base_path_mapping to update the base_mapping because it doesnt


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Adjust retry and exponential backoff for base path mapping in case of rate limit issues with larger applications. 

    2 ** c.retries * c.config.retry_base_delay

The max delay will be 2 ** 7 * 0.6 = 76.8s

## Context

Running into deploy issues with larger apps and custom domains.

## How to Test

Deploy a large app, 150+ lambda functions

## Version Changes

Patch