### PR TITLE
Improve Rate Limit Handling

### DIFF
--- a/lib/jets/aws_services.rb
+++ b/lib/jets/aws_services.rb
@@ -16,52 +16,80 @@ module Jets::AwsServices
   include StackStatus
 
   def apigateway
-    Aws::APIGateway::Client.new
+    Aws::APIGateway::Client.new(aws_options)
   end
   global_memoize :apigateway
 
   def cfn
-    Aws::CloudFormation::Client.new
+    Aws::CloudFormation::Client.new(aws_options)
   end
   global_memoize :cfn
 
   def dynamodb
-    Aws::DynamoDB::Client.new
+    Aws::DynamoDB::Client.new(aws_options)
   end
   global_memoize :dynamodb
 
   def aws_lambda
-    Aws::Lambda::Client.new
+    Aws::Lambda::Client.new(aws_options)
   end
   global_memoize :aws_lambda
 
   def logs
-    Aws::CloudWatchLogs::Client.new
+    Aws::CloudWatchLogs::Client.new(aws_options)
   end
   global_memoize :logs
 
   def s3
-    Aws::S3::Client.new
+    Aws::S3::Client.new(aws_options)
   end
   global_memoize :s3
 
   def s3_resource
-    Aws::S3::Resource.new
+    Aws::S3::Resource.new(aws_options)
   end
   global_memoize :s3_resource
 
   def sns
-    Aws::SNS::Client.new
+    Aws::SNS::Client.new(aws_options)
   end
   global_memoize :sns
 
   def sqs
-    Aws::SQS::Client.new
+    Aws::SQS::Client.new(aws_options)
   end
   global_memoize :sqs
 
   def sts
-    Aws::STS::Client.new
+    Aws::STS::Client.new(aws_options)
   end
   global_memoize :sts
+
+  # Override the AWS retry settings with Jets AWS clients.
+  #
+  # The aws-sdk-core has exponential backup with this formula:
+  #
+  #   2 ** c.retries * c.config.retry_base_delay
+  #
+  # So the max delay will be 2 ** 7 * 0.6 = 76.8s
+  #
+  # Only scoping this to deploy because dont want to affect people's application that use the aws sdk.
+  #
+  # There is also additional rate backoff logic elsewhere, since this is only scoped to deploys.
+  #
+  # Useful links:
+  #   https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb
+  #   https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+  #
+  def aws_options
+    options = {
+      retry_limit: 7, # default: 3
+      retry_base_delay: 0.6, # default: 0.3
+    }
+    options.merge!(
+      log_level: :debug,
+      logger: Logger.new($stdout),
+    ) if ENV['JETS_DEBUG_AWS_SDK']
+    options
+  end
 end

--- a/lib/jets/commands/clean/log.rb
+++ b/lib/jets/commands/clean/log.rb
@@ -26,20 +26,7 @@ class Jets::Commands::Clean
     end
 
     def delete_log_group(log_group_name)
-      retries = 0
       logs.delete_log_group(log_group_name: log_group_name)
-    rescue Aws::CloudWatchLogs::Errors::ThrottlingException => e
-      retries += 1
-      seconds = 2 ** retries
-
-      puts "WARN: delete_log_group #{e.class} #{e.message}".color(:yellow)
-      puts "Backing off and will retry in #{seconds} seconds."
-      sleep(seconds)
-      if seconds > 90 # 2 ** 6 is 64 so will give up after 6 retries
-        puts "Giving up after #{retries} retries"
-      else
-        retry
-      end
     end
 
     def clean_deploys

--- a/lib/jets/commands/delete.rb
+++ b/lib/jets/commands/delete.rb
@@ -44,27 +44,7 @@ class Jets::Commands::Delete
   end
 
   def confirm_project_exists
-    retries = 0
-    begin
-      cfn.describe_stacks(stack_name: parent_stack_name)
-    rescue Aws::CloudFormation::Errors::ValidationError
-      # Aws::CloudFormation::Errors::ValidationError is thrown when the stack
-      # does not exist
-      puts "The parent stack #{Jets.config.project_namespace.color(:green)} for the project #{Jets.config.project_name.color(:green)} does not exist. So it cannot be deleted."
-      exit 0
-    rescue Aws::CloudFormation::Errors::Throttling => e
-      retries += 1
-      seconds = 2 ** retries
-
-      puts "WARN: confirm_project_exists #{e.class} #{e.message}".color(:yellow)
-      puts "Backing off and will retry in #{seconds} seconds."
-      sleep(seconds)
-      if seconds > 90 # 2 ** 6 is 64 so will give up after 6 retries
-        puts "Giving up after #{retries} retries"
-      else
-        retry
-      end
-    end
+    cfn.describe_stacks(stack_name: parent_stack_name)
   end
 
   def empty_s3_bucket

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -59,26 +59,11 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
 
     def method_uri(resource_id, http_method)
       # https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
-      retries = 0
-      begin
-        resp = apigateway.get_method(
-          rest_api_id: rest_api_id,
-          resource_id: resource_id,
-          http_method: http_method
-        )
-      rescue Aws::APIGateway::Errors::TooManyRequestsException => e
-        retries += 1
-        seconds = 2 ** retries
-
-        puts "WARN: method_uri #{e.class} #{e.message}".color(:yellow)
-        puts "Backing off and will retry in #{seconds} seconds."
-        sleep(seconds)
-        if seconds > 90 # 2 ** 6 is 64 so will give up after 6 retries
-          puts "Giving up after #{retries} retries"
-        else
-          retry
-        end
-      end
+      resp = apigateway.get_method(
+        rest_api_id: rest_api_id,
+        resource_id: resource_id,
+        http_method: http_method
+      )
       resp.method_integration.uri
     end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Configure jets AWS clients only with longer retry settings to handle rating limiting issues. 

The aws-sdk-core has exponential backup with this formula:

    2 ** c.retries * c.config.retry_base_delay

So the max delay will be 2 ** 7 * 0.6 = 76.8s

Before it the `aws_config_update!` would do it globally and possibly affect user app code.

## Context

Folks with large jets apps, 150+ lambda functions, are running into rate limiting issues. This should substantially reduce the issues as all Jets AWS clients are being handled. This also cleans up the code a lot.

## How to Test

Deploy large jets app, 150+ lambda functions, over and over.  Note: The rate limits seem to only occur right after deploying the full app from scratch first and then deploying again. This is because for the 2nd, 3rd, etc deploys, only increment changes are needed to deploy and it's harder to run into rate limit issues, though it still does happen.

## Version Changes

Patch