### PR TITLE
Rewrite PLATFORMS section to specify Ruby only

### DIFF
--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -176,14 +176,23 @@ module Jets::Builders
       end
 
       # Make sure platform is ruby
-      lines, new_lines, marker = new_lines, [], false
+      lines, new_lines, in_platforms_section, platforms_rewritten = new_lines, [], false, false
       lines.each do |l|
-        if marker # the next loop has the platform we want to replace
+        if in_platforms_section && platforms_rewritten # once PLATFORMS has been found, skip all lines until the next section
+          if l.present?
+            next
+          else
+            in_platforms_section = false
+          end
+        end
+
+        if in_platforms_section && !platforms_rewritten # specify ruby as the only platform
           new_lines << "  ruby\n"
-          marker = false
+          platforms_rewritten = true
           next
         end
-        marker = l.include?('PLATFORMS')
+
+        in_platforms_section = l.include?('PLATFORMS')
         new_lines << l
       end
 


### PR DESCRIPTION
This is a 🐞 bug fix.

## Summary & Context

This fixes https://github.com/boltops-tools/jets/issues/594 where the PLATFORMS section of Gemfile.lock was not being properly overwritten when multiple values were declared, as in my case. For instance:

```
PLATFORMS
  x86_64-darwin-18
  x86_64-darwin-19
```

was resulting in:

```
PLATFORMS
  ruby
  x86_64-darwin-19
```

when for Lambda purposes it needed to be:

```
PLATFORMS
  ruby
 ```
 
 This resolves.

## How to Test

Change the PLATFORMS section of Gemfile.lock to have multiple declarations such as above, then download the code from AWS after deployment to see that it should only reflect the single value `ruby`.

## Version Changes

Whatever the next reasonable release is.

