### PR TITLE
Update ruby_packager.rb

### DIFF
--- a/lib/jets/builders/ruby_packager.rb
+++ b/lib/jets/builders/ruby_packager.rb
@@ -3,7 +3,9 @@ require "bundler" # for clean_old_submodules only
 module Jets::Builders
   class RubyPackager
     include Util
-
+    
+    GEM_REGEXP = /-(arm|x)\d+.*-(darwin|linux)/    
+    
     attr_reader :full_app_root
     def initialize(relative_app_root)
       @full_app_root = "#{build_area}/#{relative_app_root}"
@@ -169,9 +171,7 @@ module Jets::Builders
       # Replace things like nokogiri (1.11.1-x86_64-darwin) => nokogiri (1.11.1)
       lines, new_lines = new_lines, []
       lines.each do |l|
-        if l.include?("-x86_64-darwin")
-          l = l.sub('-x86_64-darwin','')
-        end
+        l.sub!(GEM_REGEXP, '') if l =~ GEM_REGEXP
         new_lines << l
       end
 


### PR DESCRIPTION
This is a 🐞 bug fix.

## Summary

Replace things like:
```
nokogiri (1.12.5-x86_64-darwin) => nokogiri (1.12.5)
nokogiri (1.12.5-arm64-darwin) => nokogiri (1.12.5)
nokogiri (1.12.5-arm64-linux) => nokogiri (1.12.5)
```
## Context

This can work in tandem with #610 to address things like nokogiri-1.12.5-arm64-darwin
that arise when using an M1 mac. 

When deploying from an M1 mac the gems layer includes: 

```
nokogiri-1.12.5-arm64-darwin
nokogiri-1.12.5-x86_64-linux
```

This causes lambda to raise an error:

```
Could not find nokogiri-1.12.5 in any of the sources"
```

However, if the platform is ruby or includes x86_64-linux then bundler can find nokogiri. If we strip platform from the gem name in ruby_packager then it seems like serverless gems replaces nokogiri and the lambda function works as expected. 

