### PR TITLE
support zeitwerk 2.5

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "shotgun"
   spec.add_dependency "text-table"
   spec.add_dependency "thor"
-  spec.add_dependency "zeitwerk", "~> 2.4.0"
+  spec.add_dependency "zeitwerk", "~> 2.5.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"

--- a/lib/jets.rb
+++ b/lib/jets.rb
@@ -28,4 +28,7 @@ module Jets
   extend Core # root, logger, etc
 end
 
-Jets::Autoloaders.once.preload("#{__dir__}/jets/db.rb") # required for booter.rb: setup_db
+# required for booter.rb: setup_db
+Jets::Autoloaders.once.on_setup do
+  Jets::Db
+end

--- a/lib/jets/autoloaders.rb
+++ b/lib/jets/autoloaders.rb
@@ -48,6 +48,9 @@ module Jets
             loader.do_not_eager_load("#{__dir__}/#{path}")
           end
 
+          internal_turbine_path = "#{__dir__}/internal/turbines"
+          loader.push_dir(internal_turbine_path)
+
           do_not_eager_load_paths.each do |path|
             loader.do_not_eager_load("#{__dir__}/#{path}")
           end

--- a/lib/jets/booter.rb
+++ b/lib/jets/booter.rb
@@ -43,7 +43,6 @@ class Jets::Booter
     # We eager load the extensions and then use the loaded modules to extend Jets::Stack directly.
     # Originally used an included hook but thats too early before app/shared/extensions is in the load_path.
     def load_shared_extensions
-      Jets::Autoloaders.once.preload("#{Jets.root}/app/shared/extensions")
       base_path = "#{Jets.root}/app/shared/extensions"
       Dir.glob("#{base_path}/**/*.rb").each do |path|
         next unless File.file?(path)
@@ -103,8 +102,8 @@ class Jets::Booter
     end
 
     def load_internal_turbines
-      Dir.glob("#{__dir__}/internal/turbines/**/*.rb").each do |path|
-        Jets::Autoloaders.once.preload(path)
+      Jets::Autoloaders.once.on_setup do
+        Jets::Mailer # only one right now
       end
     end
 

--- a/lib/jets/commands/templates/skeleton/Gemfile.tt
+++ b/lib/jets/commands/templates/skeleton/Gemfile.tt
@@ -18,7 +18,7 @@ gem "mysql2", "~> 0.5.3"
 <% unless options[:mode] == 'job' -%>
 gem "dynomite"
 <% end -%>
-gem "zeitwerk", "~> 2.4.0"
+gem "zeitwerk", "~> 2.5.0"
 
 # development and test groups are not bundled as part of the deployment
 group :development, :test do

--- a/lib/jets/stack.rb
+++ b/lib/jets/stack.rb
@@ -61,15 +61,6 @@ module Jets
       end
       memoize :template
 
-      # Eager loading the app/shared resources to ensure shared resources have been registered.
-      # Not being used anymore but keeping around just in case for now.
-      def eager_load_shared_resources!
-        Dir.glob("#{Jets.root}/app/shared/**").each do |path|
-          next if path.include?("app/shared/functions")
-          Jets::Autoloaders.main.preload(path)
-        end
-      end
-
       def lookup(logical_id)
         looker.output(logical_id)
       end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Support zeitwerk 2.5.  

* The `jets new` command generates a Gemfile that pins to `gem "zeitwerk", ~> 2.5.0`
* The `jets.gemspec` also requires zeitwerk 2.5.x. 
* Important: Zeitwerk does not support the old interface used in jets 3.0.2. IE: zeitwerk_loader.preload (old and has been removed) zeitwerk_loader.on_setup (new and takes in a block instead of a string).
* Users must upgrade to zeitwerk 2.5.x when upgrading to jets 3.1

## How to Update

When upgrading to jets 3.1, you should 

1. unpin zeitwerk in your Gemfile and pin it to `gem "zeitwerk", ~> 2.5.0` or 
2. leave the version unpinned entirely and then run:

    bundle update

Not supporting zeitwerk 2.4.x and below after jets 3.1

## Context

#601

## How to Test

Unpin zeitwerk in your jets project Gemfile and run bundle update.

## Version Changes

Minor