### PR TITLE
adjust required_ruby_version

### DIFF
--- a/jets.gemspec
+++ b/jets.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://rubyonjets.com"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = ['>= 2.5.0', '< 3.0.0']
   spec.rdoc_options += Jets::Rdoc.options
 
   vendor_files       = Dir.glob("vendor/**/*")


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Update the jets.gemspec required_ruby_version to `>= 2.5` and `< 3`. A little bit surprised the specifier allowed 2.7. Unsure why. Fixing it anyway.

## How to Test

Deploy jets app as sanity check

## Version Changes

Patch