### PR TITLE
Jets Console accepts environment cli argument

### DIFF
--- a/lib/jets/cli.rb
+++ b/lib/jets/cli.rb
@@ -63,7 +63,8 @@ class Jets::CLI
     # Pretty tricky, we need to use the raw @given_args as thor_args eventually calls Commands::Base#eager_load!
     # which uses Jets.env before we get a chance to override ENV['JETS_ENV']
     command, env = @given_args[0..1]
-    return unless %w[deploy delete].include?(command)
+
+    return unless %w[deploy delete console c].include?(command)
     env = nil if env&.starts_with?('-')
     return unless env
     ENV['JETS_ENV'] = env ? env : 'development'

--- a/lib/jets/commands/console.rb
+++ b/lib/jets/commands/console.rb
@@ -1,5 +1,11 @@
 class Jets::Commands::Console
-  def self.run
+  attr_reader :environment
+
+  def initialize(environment)
+    @environment = environment
+  end
+
+  def run
     puts Jets::Booter.message
 
     # Thanks: https://mutelight.org/bin-console

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -61,10 +61,13 @@ module Jets::Commands
       Jets::Router.validate_routes!
     end
 
-    desc "console", "REPL console with Jets environment loaded"
+    desc "console [environment]", "REPL console with Jets environment loaded"
     long_desc Help.text(:console)
-    def console
-      Console.run
+    # Note the environment is here to trick the Thor parser to allowing an
+    # environment parameter. It is not actually set here.  It is set earlier
+    # in cli.rb: set_jets_env_from_cli_arg!
+    def console(environment=nil)
+      Console.new(options).run
     end
 
     desc "runner", "Run Ruby code in the context of Jets app non-interactively"

--- a/spec/lib/jets/commands/console_spec.rb
+++ b/spec/lib/jets/commands/console_spec.rb
@@ -1,0 +1,21 @@
+describe Jets::Commands::Console do
+    let(:build) do
+      Jets::Commands::Console.new(provided_environment_name)
+    end
+  
+    describe "Console" do
+      context 'with environment' do
+        let(:provided_environment_name) { "sandbox" }
+        it "accepts environment" do
+            expect(build.environment).to eq provided_environment_name
+        end
+      end
+
+      context "no environment" do
+        let(:provided_environment_name) { nil }
+        it 'defaults to development' do
+            expect(build.environment).to eq nil
+        end
+      end
+    end
+end


### PR DESCRIPTION


<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Lets `jets console` accept environment as an argument. 

```
  $ jets console sandbox
   Jets booting up in sandbox mode! 
```

## Context

This really just uses the set_jets_env_from_cli_arg! hack. 

## How to Test

```
bundle exec rspec spec/lib/jets/commands/console_spec.rb
```

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

