### PR TITLE
aws options to better handle rate limit for base path mapping

### DIFF
--- a/lib/jets/internal/app/functions/jets/base_path_mapping.rb
+++ b/lib/jets/internal/app/functions/jets/base_path_mapping.rb
@@ -91,10 +91,22 @@ class BasePathMapping
   end
 
   def apigateway
-    @apigateway ||= Aws::APIGateway::Client.new
+    @apigateway ||= Aws::APIGateway::Client.new(aws_options)
   end
 
   def cfn
-    @cfn ||= Aws::CloudFormation::Client.new
+    @cfn ||= Aws::CloudFormation::Client.new(aws_options)
+  end
+
+  def aws_options
+    options = {
+      retry_limit: 7, # default: 3
+      retry_base_delay: 0.6, # default: 0.3
+    }
+    options.merge!(
+      log_level: :debug,
+      logger: Logger.new($stdout),
+    ) if ENV['JETS_DEBUG_AWS_SDK']
+    options
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

For large apps, at the end of the deployment, the `jets url` internal call could sometimes hit the rate limit. It uses base_path_mapping to grab the url. Adjust the aws client options with longer stagger options. This also helps custom domains.

## How to Test

Sanity check

## Version Changes

Patch