### PR TITLE
loosen zeitwerk  dependency in generated project Gemfile

### DIFF
--- a/lib/jets/commands/templates/skeleton/Gemfile.tt
+++ b/lib/jets/commands/templates/skeleton/Gemfile.tt
@@ -18,7 +18,7 @@ gem "mysql2", "~> 0.5.3"
 <% unless options[:mode] == 'job' -%>
 gem "dynomite"
 <% end -%>
-gem "zeitwerk", "~> 2.5.0"
+gem "zeitwerk", ">= 2.5.0"
 
 # development and test groups are not bundled as part of the deployment
 group :development, :test do


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Loosen the zeitwork dependency version in generated project Gemfile.

## Context

Ran into some warnings it whenever zeitwork doesn't match with the system installed one. Loosening it so warning goes away and probably less work for users overall.

## How to Test

Deploy demo jets app and make sure it works.

## Version Changes

Patch