### PR TITLE
Implement vpc_endpoint_ids configuration

### DIFF
--- a/docs/_docs/app-config.md
+++ b/docs/_docs/app-config.md
@@ -38,6 +38,7 @@ Jets.application.configure do
   # config.api.binary_media_types = ['multipart/form-data'] # default is ['multipart/form-data'] # Changing this will update the API Gateway DNS
   # config.api.endpoint_type = 'PRIVATE' # Default is 'EDGE' https://amzn.to/2r0Iu2L, you need to set an endpoint_policy if this is 'PRIVATE'
   # config.api.endpoint_policy = {} # Default is nil https://amzn.to/2r0Iu2L
+  # config.api.vpc_endpoint_ids = [] # Default is nil https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html
 end
 ```
 

--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -99,6 +99,7 @@ class Jets::Application
       config.api.cors_authorization_type = nil # nil so ApiGateway::Cors#cors_authorization_type handles
       config.api.endpoint_policy = nil # required when endpoint_type is EDGE
       config.api.endpoint_type = 'EDGE' # PRIVATE, EDGE, REGIONAL
+      config.api.vpc_endpoint_ids = nil
 
       config.api.authorizers = ActiveSupport::OrderedOptions.new
       config.api.authorizers.default_token_source = "Auth" # method.request.header.Auth

--- a/lib/jets/resource/api_gateway/rest_api.rb
+++ b/lib/jets/resource/api_gateway/rest_api.rb
@@ -5,6 +5,7 @@ module Jets::Resource::ApiGateway
         name: Jets::Naming.gateway_api_name,
         endpoint_configuration: { types: endpoint_types }
       }
+      properties[:endpoint_configuration][:vpc_endpoint_ids] = vpce_ids if vpce_ids
       properties[:binary_media_types] = binary_media_types if binary_media_types
       properties[:policy] = endpoint_policy if endpoint_policy
 
@@ -59,6 +60,15 @@ module Jets::Resource::ApiGateway
       return nil if endpoint_policy.nil? || endpoint_policy.empty?
 
       endpoint_policy
+    end
+
+    private
+
+    def vpce_ids
+      ids = Jets.config.api.vpc_endpoint_ids
+      return nil if ids.nil? || ids.empty?
+
+      ids
     end
   end
 end

--- a/spec/lib/jets/resource/api_gateway/rest_api_spec.rb
+++ b/spec/lib/jets/resource/api_gateway/rest_api_spec.rb
@@ -1,18 +1,35 @@
 describe Jets::Resource::ApiGateway::RestApi do
 
   context 'endpoint configuration' do
-    let(:endpoint_types) do
-      Jets::Resource::ApiGateway::RestApi.new.properties["EndpointConfiguration"]["Types"]
+    let(:endpoint_config) do
+      Jets::Resource::ApiGateway::RestApi.new.properties['EndpointConfiguration']
     end
 
-    it 'defaults to edge-optimized' do
-      allow(Jets.config.api).to receive(:endpoint_type).and_return('EDGE')
-      expect(endpoint_types).to eq ['EDGE']
+    context 'type' do
+      let(:endpoint_types) { endpoint_config['Types'] }
+
+      it 'defaults to edge-optimized' do
+        allow(Jets.config.api).to receive(:endpoint_type).and_return('EDGE')
+        expect(endpoint_types).to eq ['EDGE']
+      end
+
+      it 'can be set explicitly' do
+        allow(Jets.config.api).to receive(:endpoint_type).and_return('PRIVATE')
+        expect(endpoint_types).to eq ['PRIVATE']
+      end
     end
 
-    it 'can be set explicitly' do
-      allow(Jets.config.api).to receive(:endpoint_type).and_return('PRIVATE')
-      expect(endpoint_types).to eq ['PRIVATE']
+    context 'vpc endpoint ids' do
+      let(:vpc_endpoint_ids) { endpoint_config['VpcEndpointIds'] }
+
+      it 'defaults to nil' do
+        expect(vpc_endpoint_ids).to be_nil
+      end
+
+      it 'can be set explicitly' do
+        allow(Jets.config.api).to receive(:vpc_endpoint_ids).and_return(['vpce-1234'])
+        expect(vpc_endpoint_ids).to eq ['vpce-1234']
+      end
     end
   end
 


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

We needed a private gateway with a vpc endpoint and wanted the CloudFormation stack to handle all of the configuration on its gateway

This PR implements a `config.api.vpc_endpoint_ids` configuration. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html