### PR TITLE
Readme: Replace "splat out" with "had" a baby

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="http://rubyonjets.com"><img src="http://rubyonjets.com/img/logos/jets-logo-full.png" /></a>
 </div>
 
-Ruby and Lambda splat out a baby and that child's name is [Jets](http://rubyonjets.com/).
+Ruby and Lambda had a baby and that child's name is [Jets](http://rubyonjets.com/).
 
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZ08vK2hjOHczQUVoUDhSYnBNNUU4T0gxQWJuOTlLaXpwVGQ1NjJ3NnVDY1dSdFVXQ3d2VXVSQzRFcU1qd1JPMndFZlByRktIcTUrZm5GWlM5dHpjM1ZrPSIsIml2UGFyYW1ldGVyU3BlYyI6Imluc1Qrd25GanhUdHlidjUiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 [![CircleCI](https://circleci.com/gh/boltops-tools/jets.svg?style=svg)](https://circleci.com/gh/boltops-tools/jets)


### PR DESCRIPTION
Exciting project! I've been looking for something like this for a long time.

In the first line of the Readme it currently says "Ruby and Lambda splat out a baby".

"Splat out" here seems incorrect - at least it read that way to me when I came across this repo. 

"Spat out" is possibly what you meant, but then writing something like that in line one of the Readme doesn't give a great impression!

How about "had a baby", which comes across much more positively and doesn't interrupt the user by making them think about "splat out" versus "spat out" versus "had"?

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

