### PR TITLE
Base path mapping

### DIFF
--- a/lib/jets/internal/app/functions/jets/base_path.rb
+++ b/lib/jets/internal/app/functions/jets/base_path.rb
@@ -1,13 +1,49 @@
-require 'bundler/setup'
+begin
+  require 'bundler/setup'
+  # When require bundler/setup fails, AWS Lambda won't be able to load base_path_mapping
+  # So we'll require base_path_mapping within begin/rescue block so that it does not also
+  # fail the entire lambda function.
+  require 'jets/internal/app/functions/jets/base_path_mapping'
+rescue Exception => e
+  # Note: rescue LoadError is not enough in AWS Lambda environment
+  # Actual exceptions:
+  #   require bundler/setup: Ruby exception "Bundler::GemNotFound"
+  #   require base_path_mappnig: AWS Lambda reported error "errorType": "Init<LoadError>"
+  # Will use a generic rescue Exception though in case error changes in the future.
+  puts "WARN: #{e.class} #{e.message}"
+  puts <<~EOL
+    Could not require bundler/setup.
+    This can happen for weird timeout missing error. Example:
+
+        Could not find timeout-0.3.2 in locally installed gems
+
+    Happens when the gem command is out-of-date on old versions of ruby 2.7.
+    See: https://community.boltops.com/t/could-not-find-timeout-0-3-1-in-any-of-the-sources/996
+  EOL
+end
 require 'cfn_response'
-require 'jets/internal/app/functions/jets/base_path_mapping'
 
 STAGE_NAME = "<%= @stage_name %>"
 
 def lambda_handler(event:, context:)
   cfn = CfnResponse.new(event, context)
   cfn.response do
-    mapping = BasePathMapping.new(event, STAGE_NAME)
+    # Super edge case: mapping is nil when require bundler/setup fails
+    begin
+      mapping = BasePathMapping.new(event, STAGE_NAME)
+    rescue NameError => e
+      puts "ERROR: #{e.class} #{e.message}"
+      puts error_message
+    end
+
+    # This is the "second pass" of CloudFormation when it tries to delete the BasePathMapping during rollback
+    if mapping.nil? && event['RequestType'] == "Delete"
+      cfn.success # so that CloudFormation can continue the delete process from a rollback
+      delay
+      return
+    end
+
+    # Normal behavior when mapping is not nil when bundler/setup loads successfully
     case event['RequestType']
     when "Create", "Update"
       mapping.update
@@ -15,4 +51,58 @@ def lambda_handler(event:, context:)
       mapping.delete(true) if mapping.should_delete?
     end
   end
+end
+
+def delay
+  puts "Delaying 60 seconds to allow user some time to see lambda function logs."
+  60.times do
+    puts Time.now
+    sleep 1
+  end
+end
+
+def error_message
+  <<~EOL
+  This is ultimately the result of require bundler/setup failing to load.
+  On the CloudFormation first pass, the BasePathMapping fails to CREATE.
+  CloudFormation does a rollback and tries to delete the BasePathMapping.
+
+  Jets will send a success response to CloudFormation so it can continue and delete
+  BasePathMapping on the rollback. Otherwise, CloudFormation ends up in the terminal
+  UPDATE_FAILED state and the CloudFormation console provides 3 options:
+
+      1) retry 2) update 3) rollback.
+
+  The only option that seems to work is rollback to get it out of UPDATE_FAILED to
+  UPDATE_ROLLBACK_COMPLETE. But then, if we `jets deploy` again without fixing the
+  require bundler/setup issue, we'll end back up in the UPDATE_FAILED state.
+
+  Will handle this error so we can continue the stack because we do not want it to fail
+  and never be able to send the CfnResponse. Then we have to wait hours for a CloudFormation timeout.
+  Sometimes deleting the APP-dev-ApiDeployment20230518230443-EXAMPLEY8YQP0 stack
+  allows the cloudformation stacks to continue, but usually, it'll only just slightly speed up the rollback.
+
+  Some examples of actual rollback times:
+
+  When left alone, the rollback takes about 2.5 hours.
+
+      2023-05-19 05:39:25  User Initiated
+      2023-05-19 08:01:48  UPDATE_ROLLBACK_COMPLETE
+
+  When deleting the APP-dev-ApiDeployment20230518230443-EXAMPLEY8YQP0 stack, it takes about 1.5 hours.
+
+      2023-05-19 06:25:41  User Initiated
+      2023-05-19 07:47:03  UPDATE_ROLLBACK_COMPLETE
+
+  Rescuing and handling the error here allows the CloudFormation stack to continue and finish the rollback process.
+  It takes the rollback time down to about 3 minutes. Example:
+
+      2023-05-19 16:34:19 User Initiated
+      2023-05-19 16:37:34 UPDATE_ROLLBACK_COMPLETE
+
+  Note: The first cloudformation CREATE pass sends FAILED Status to CloudFormation,
+  and the second cloudformation DELETE pass sends SUCCESS Status to CloudFormation.
+
+  Related: https://community.boltops.com/t/could-not-find-timeout-0-3-1-in-any-of-the-sources/996
+  EOL
 end

--- a/lib/jets/internal/app/functions/jets/base_path_mapping.rb
+++ b/lib/jets/internal/app/functions/jets/base_path_mapping.rb
@@ -28,8 +28,28 @@ class BasePathMapping
   # Cannot use update_base_path_mapping to update the base_mapping because it doesnt
   # allow us to change the rest_api_id. So we delete and create.
   def update
-    delete(true)
-    create
+    puts "BasePathMapping update"
+    if rest_api_changed?
+      delete(true)
+      create
+    else
+      puts "BasePathMapping update: rest_api_id #{rest_api_id} did not change. Skipping."
+    end
+
+    puts "BasePathMapping update complete"
+  end
+
+  def rest_api_changed?
+    puts "BasePathMapping checking if rest_api_id changed"
+    mapping = current_base_path_mapping
+    return true unless mapping
+    mapping.rest_api_id != rest_api_id
+  end
+
+  def current_base_path_mapping
+    resp = apigateway.get_base_path_mapping(base_path: "(none)", domain_name: domain_name)
+  rescue Aws::APIGateway::Errors::NotFoundException
+    return nil
   end
 
   # Dont delete the newly created base path mapping unless this is an operation
@@ -39,10 +59,14 @@ class BasePathMapping
   end
 
   def delete(fail_silently=false)
-    apigateway.delete_base_path_mapping(
+    puts "BasePathMapping delete"
+    options = {
       domain_name: domain_name, # required
       base_path: base_path.empty? ? '(none)' : base_path,
-    )
+    }
+    puts "BasePathMapping delete options #{options.inspect}"
+    apigateway.delete_base_path_mapping(options)
+    puts "BasePathMapping delete complete"
   # https://github.com/tongueroo/jets/issues/255
   # Used to return: Aws::APIGateway::Errors::NotFoundException
   # Now returns: Aws::APIGateway::Errors::InternalFailure
@@ -52,12 +76,41 @@ class BasePathMapping
   end
 
   def create
-    apigateway.create_base_path_mapping(
+    puts "BasePathMapping create"
+    options = {
       domain_name: domain_name, # required
       base_path: base_path,
       rest_api_id: rest_api_id, # required
       stage: @stage_name,
-    )
+    }
+    puts "BasePathMapping create options #{options.inspect}"
+    apigateway.create_base_path_mapping(options)
+    puts "BasePathMapping create complete"
+  rescue Aws::APIGateway::Errors::ServiceError => e
+    puts "ERROR: #{e.class}: #{e.message}"
+    puts "BasePathMapping create failed"
+    if e.message.include?("Invalid domain name identifier specified")
+      puts <<~EOL
+        This super edge case error seems to happen when the cloudformation stack does a rollback
+        because the BasePathMapping custom resource fails. This has happened with a strange combination of
+        ruby 2.7 and the timeout gem not being picked up in the AWS Lambda runtime environment
+        Specifically, when jets deploy was used with a rubygems install that is out-of-date.
+        See: https://community.boltops.com/t/could-not-find-timeout-0-3-1-in-any-of-the-sources/996
+
+        The new base path mapping is not created correctly and the old base path mapping is not properly deleted.
+        The old ghost base mapping interferes with the new base path mapping.
+        The workaround solution seems to require removing all the config.domain settings and deploying again. Example:
+
+        config/application.rb
+
+            config.domain.cert_arn = "arn:aws:acm:us-west-2:111111111111:certificate/EXAMPLE1-a3de-4fe7-b72e-4cc153c5303e"
+            config.domain.hosted_zone_name = "example.com"
+
+        Comment out those settings, deploy, then uncomment and deploy again.
+        If there's a better workaround, please let us know.
+      EOL
+    end
+    raise(e)
   end
 
   def deployment_stack
@@ -109,4 +162,10 @@ class BasePathMapping
     ) if ENV['JETS_DEBUG_AWS_SDK']
     options
   end
+end
+
+if __FILE__ == $0
+  event = JSON.load(File.read(ARGV[0]))
+  context = nil # stub out
+  BasePathMapping.new(event, context).update
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Been running into this super-edge case from time to time over the years. Essentially, if the BasePathMapping Custom CloudFormation resource Lambda function errors super early before it gets to the [cfn_response logic](https://github.com/boltops-tools/jets/blob/fccf6156b51f84cbd99a9f0c428904f86ee9684e/lib/jets/internal/app/functions/jets/base_path.rb#L9-L17) then the Lambda function will not have the opportunity to send a SUCCESS or FAILED status back to CloudFormation. This results in the Custom Resource waiting until it eventually times out. The timeout can take 3 hours!  

The super-edge case can be caused by an outdated rubygems install on ruby 2.7. See: https://community.boltops.com/t/could-not-find-timeout-0-3-1-in-any-of-the-sources/996

Quite annoying to track this one down. 

* The fix ensures a FAILED signal is sent on the 1st cloudformation update pass. 
* Then cloudformation will rollback the stack.
* On the 2nd cloudformation rollback pass, a SUCCESS signal is sent so we tell the CloudFormation service that the BasePathMapping is "deleted".

This takes the rollback times down from 3 hours to 3 minutes for a much better user-experience. Note: I added a 60s delay just so the user has some time to try to track down the Lambda function logs before it gets cleaned up by the cloudformation rollback process.

## Context

Ran into it while updating a jets app.

## How to Test

Using the AWS codebuild `aws/codebuild/amazonlinux2-x86_64-standard:3.0` image without updating rubygems will reproduce this issue actually. Also see: https://community.boltops.com/t/could-not-find-timeout-0-3-1-in-any-of-the-sources/996

Set up one of those environments and test that the rollback only takes about 3 minutes.

## Version Changes

Patch