### PR TITLE
bundle check and prevent error from getting to aws lambda

### DIFF
--- a/lib/jets/builders/gem_replacer.rb
+++ b/lib/jets/builders/gem_replacer.rb
@@ -1,6 +1,8 @@
 module Jets::Builders
   class GemReplacer
     extend Memoist
+    include Util
+    
     def initialize(options)
       @options = options
     end
@@ -35,13 +37,6 @@ module Jets::Builders
 
       dest = src.sub("-darwin", "-linux")
       FileUtils.mv(src, dest) unless File.exist?(dest) # looks like rename_gem actually runs twice
-    end
-
-    def sh(command)
-      puts "=> #{command}".color(:green)
-      success = system(command)
-      abort("Command Failed: #{command}") unless success
-      success
     end
 
     def ruby_folder


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Run `bundle check` right after `bundle install` to verify that gems are installed properly. This prevents the deployment getting all the way to AWS Lambda and the user finding out painfully post deployment.

## Context

Related: https://community.boltops.com/t/could-not-find-timeout-0-3-1-in-any-of-the-sources/996

## How to Test

Sanity check. Deploy demo app.

## Version Changes

Patch