### PR TITLE
JETS_EXTRA support, deprecate JETS_ENV_EXTRA

### DIFF
--- a/lib/jets/application.rb
+++ b/lib/jets/application.rb
@@ -163,13 +163,12 @@ class Jets::Application
     staging: 'stag',
   }
   def set_computed_configs!
-    # env_extra can be also be set with JETS_ENV_EXTRA.
-    # JETS_ENV_EXTRA higher precedence than config.env_extra
-    config.env_extra = ENV['JETS_ENV_EXTRA'] if ENV['JETS_ENV_EXTRA']
-    # IE: With env_extra: project-dev-1
-    #     Without env_extra: project-dev
+    # env var JETS_EXTRA higher precedence than config.extra
+    config.extra = Jets.extra
+    # IE: With extra: project-dev-1
+    #     Without extra: project-dev
     config.short_env = ENV_MAP[Jets.env.to_sym] || Jets.env
-    # table_namespace does not have the env_extra, more common case desired.
+    # table_namespace does not have the extra, more common case desired.
     config.table_namespace = [config.project_name, config.short_env].compact.join('-')
 
     config.project_namespace = Jets.project_namespace

--- a/lib/jets/commands/clean/log.rb
+++ b/lib/jets/commands/clean/log.rb
@@ -4,7 +4,7 @@
 #   /aws/lambda/demo-dev-2-jets-preheat_job-warm
 #   /aws/lambda/demo-dev-2-jets-public_controller-show
 #
-# We're doing this because JETS_ENV_EXTRA environments can create additional matching
+# We're doing this because Jets.extra environments can create additional matching
 # log groups and we don't want to overly-aggressively delete them.
 #
 # The `keep_prefixes(log_group_names)` method calcuates the log groups to keep.
@@ -78,7 +78,7 @@ class Jets::Commands::Clean
 
     # Check for the prefixes to keep. The slightly tricky thing to watch for is
     # for the prefix matching addiitonal log groups that belong to other
-    # JETS_ENV_EXTRA=xxx created environments.
+    # JETS_EXTRA=xxx created environments.
     #
     # We find and store the prefixes to keep so we don't over aggressively delete
     # log groups.

--- a/lib/jets/commands/templates/skeleton/config/application.rb.tt
+++ b/lib/jets/commands/templates/skeleton/config/application.rb.tt
@@ -11,7 +11,7 @@ Jets.application.configure do
   # config.prewarm.public_ratio = 3 # default is 3
 <% end -%>
 
-  # config.env_extra = 2 # can also set this with JETS_ENV_EXTRA
+  # config.extra = 2 # can also set this with JETS_EXTRA
   # config.autoload_paths = []
 
   # config.asset_base_url = 'https://cloudfront.domain.com/assets' # example

--- a/lib/jets/core.rb
+++ b/lib/jets/core.rb
@@ -32,7 +32,19 @@ module Jets::Core
   end
   memoize :env
 
-  def build_root
+  @@extra_warning_shown = false
+  def extra
+    # Keep for backwards compatibility
+    unless ENV['JETS_ENV_EXTRA'].blank?
+      puts "DEPRECATION WARNING: JETS_ENV_EXTRA is deprecated. Use JETS_EXTRA instead.".color(:yellow) unless @@extra_warning_shown
+      @@extra_warning_shown = true
+      extra = ENV['JETS_ENV_EXTRA']
+    end
+    extra = ENV['JETS_EXTRA'] unless ENV['JETS_EXTRA'].blank?
+    extra
+  end
+
+def build_root
     "/tmp/jets/#{config.project_name}".freeze
   end
   memoize :build_root
@@ -76,7 +88,7 @@ module Jets::Core
   end
 
   def project_namespace
-    [config.project_name, config.short_env, config.env_extra].compact.join('-').gsub('_','-')
+    [config.project_name, config.short_env, config.extra].compact.join('-').gsub('_','-')
   end
 
   def rack?

--- a/lib/jets/dotenv.rb
+++ b/lib/jets/dotenv.rb
@@ -36,8 +36,8 @@ class Jets::Dotenv
       (root.join(".env.#{Jets.env}.local") unless @remote),
     ]
     files << root.join(".env.#{Jets.env}.remote") if @remote
-    if ENV["JETS_ENV_EXTRA"]
-      files << root.join(".env.#{Jets.env}.#{ENV["JETS_ENV_EXTRA"]}")
+    if Jets.extra
+      files << root.join(".env.#{Jets.env}.#{Jets.extra}")
     end
     files.compact
   end

--- a/lib/jets/resource/api_gateway/deployment.rb
+++ b/lib/jets/resource/api_gateway/deployment.rb
@@ -57,7 +57,7 @@ module Jets::Resource::ApiGateway
 
     def self.stage_name
       # Stage name only allows a-zA-Z0-9_
-      [Jets.config.short_env, Jets.config.env_extra].compact.join('_').gsub('-','_')
+      [Jets.config.short_env, Jets.config.extra].compact.join('_').gsub('-','_')
     end
 
     def timestamp

--- a/lib/jets/resource/lambda/function/environment.rb
+++ b/lib/jets/resource/lambda/function/environment.rb
@@ -16,7 +16,8 @@ class Jets::Resource::Lambda::Function
     def jets_env
       env = {}
       env[:JETS_ENV] = Jets.env.to_s
-      env[:JETS_ENV_EXTRA] = Jets.config.env_extra if Jets.config.env_extra
+      env[:JETS_ENV_EXTRA] = Jets.extra if Jets.extra # keep JETS_ENV_EXTRA for backwards compatibility
+      env[:JETS_EXTRA] = Jets.extra if Jets.extra
       env[:JETS_PROJECT_NAME] = ENV['JETS_PROJECT_NAME'] if ENV['JETS_PROJECT_NAME']
       env[:JETS_STAGE] = Jets::Resource::ApiGateway::Deployment.stage_name
       env[:JETS_AWS_ACCOUNT] = Jets.aws.account


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Use `JETS_EXTRA` instead of `JETS_ENV_EXTRA` for https://rubyonjets.com/docs/env-extra/ concept. Other boltops tooling use this shorter naming convention also.

Note: `JETS_ENV_EXTRA` is still supported so it doesn't break people's pipeline. A deprecation warning is shown.

## How to Test

Deploy with:

    JETS_EXTRA=2 jets deploy

## Version Changes

Minor