### PR TITLE
PreheatJob: fix function lookups and iam function permission

### DIFF
--- a/lib/jets/builders/code_builder.rb
+++ b/lib/jets/builders/code_builder.rb
@@ -80,6 +80,7 @@ module Jets::Builders
       return false if ENV['JETS_BUILD_NO_INTERNET']
       s3_key = "jets/code/#{filename}"
       begin
+        logger.debug "Checking s3://#{s3_bucket}/#{s3_key}"
         s3.head_object(bucket: s3_bucket, key: s3_key)
         true
       rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::Forbidden

--- a/lib/jets/internal/app/jobs/jets/preheat_job.rb
+++ b/lib/jets/internal/app/jobs/jets/preheat_job.rb
@@ -12,13 +12,17 @@ class Jets::PreheatJob < ApplicationJob
       sid: "Statement1",
       action: ["logs:*"],
       effect: "Allow",
-      resource: "arn:aws:logs:#{Jets.aws.region}:#{Jets.aws.account}:log-group:#{Jets.config.project_namespace}-*",
+      resource: [
+        sub("arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${WarmLambdaFunction}"),
+      ]
     },
     {
       sid: "Statement2",
       action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
       effect: "Allow",
-      resource: "arn:aws:lambda:#{Jets.aws.region}:#{Jets.aws.account}:function:#{Jets.config.project_namespace}-*",
+      resource: [
+        sub("arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${WarmLambdaFunction}")
+      ]
     }
   )
 

--- a/lib/jets/lambda/dsl.rb
+++ b/lib/jets/lambda/dsl.rb
@@ -237,6 +237,10 @@ module Jets::Lambda::Dsl
         "!Ref #{name.to_s.camelize}"
       end
 
+      def sub(value)
+        "!Sub #{value.to_s.camelize}"
+      end
+
       # meth is a Symbol
       def method_added(meth)
         return if %w[initialize method_missing].include?(meth.to_s)

--- a/lib/jets/resource/iam/base_role_definition.rb
+++ b/lib/jets/resource/iam/base_role_definition.rb
@@ -24,11 +24,6 @@ module Jets::Resource::Iam
         }
       }
 
-      definition[logical_id][:properties][:policies] = [
-        policy_name: "#{policy_name[0..127]}", # required, limited to 128-chars
-        policy_document: policy_document,
-      ] unless policy_document['Statement'].empty?
-
       unless managed_policy_arns.empty?
         definition[logical_id][:properties][:managed_policy_arns] = managed_policy_arns
       end

--- a/lib/jets/resource/iam/policy.rb
+++ b/lib/jets/resource/iam/policy.rb
@@ -1,0 +1,31 @@
+module Jets::Resource::Iam
+  class Policy < Jets::Resource::Base
+    def initialize(role)
+      @role = role
+    end
+    delegate :policy_document, :policy_name, :role_logical_id, :replacements, to: :@role
+
+    def policy_logical_id
+      role_logical_id.sub(/role$/, "policy")
+    end
+
+    def definition
+      logical_id = policy_logical_id
+
+      # Do not assign pretty role_name because long controller names might hit the 64-char
+      # limit. Also, IAM roles are global, so assigning role names prevents cross region deploys.
+      definition = {
+        logical_id => {
+          type: "AWS::IAM::Policy",
+          properties: {
+            roles: [Ref: role_logical_id.camelize],
+            policy_name: "#{policy_name[0..127]}", # required, limited to 128-chars
+            policy_document: policy_document,
+          }
+        }
+      }
+
+      definition
+    end
+  end
+end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes #440 

Also:

* Improves prewarming and fixes bugs by looking up functions to preheat cloudformation, this generalizes it and handles long function names.
* Create separate IAM Role and Policy to allow policies to reference lambda function without a circular dependency error.
* This can to require a blue/green deployment. It depends if the user has user `iam_policies` in their code.

## How to Test

Deploy an app with a name with a long enough name. IE:

```ruby
Jets.application.configure do
  config.project_name = "some-very-very-really-long-super-long-app-project-name"
  # ...
end
```

Deploy it:

    jets deploy

Confirm that really long function names that get cut off and managed by CloudFormation still produce an IAM policy that works. 

Screenshots:

<img width="1036" alt="job iam role lambda function logs" src="https://github.com/boltops-tools/jets/assets/4085/b3f4c82f-6b87-43da-9616-6ae000cdcbc0">

<img width="1244" alt="job iam role iam console" src="https://github.com/boltops-tools/jets/assets/4085/df0e55c9-7542-499d-b6f7-0d712a1dfeb6">


## Version Changes

Major - due to need of blue/green deployments