### PR TITLE
make sure logger level info is default

### DIFF
--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -51,6 +51,7 @@ class Jets::Application
       config.autoload_paths = [] # allows for customization
       config.ignore_paths = [] # allows for customization
       config.logger = Jets::Logger.new($stderr)
+      config.logger.level = Logger::INFO
       config.time_zone = "UTC"
 
       # function properties defaults


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Make sure that the `Jets.logger` level is info by default. For some reason, on some systems, it did seem to be debug.

## Version Changes

Patch