### PR TITLE
Validate lambda function names

### DIFF
--- a/lib/jets/cfn/builders/base_child_builder.rb
+++ b/lib/jets/cfn/builders/base_child_builder.rb
@@ -40,6 +40,7 @@ module Jets::Cfn::Builders
     end
 
     def add_functions
+      validate_function_names!
       add_class_iam_policy
       @app_class.tasks.each do |task|
         add_function(task)
@@ -64,6 +65,24 @@ module Jets::Cfn::Builders
 
       resource = Jets::Resource::Iam::FunctionRole.new(task)
       add_resource(resource)
+    end
+
+    def validate_function_names!
+      invalids = @app_class.tasks.reject do |task|
+        task.meth =~ /^[a-zA-Z][a-zA-Z0-9_]$/
+      end
+      return if invalids.empty?
+      list = invalids.map do |task|
+        "    #{task.class_name}##{task.meth}" # IE: PostsController#index
+      end.join("\n")
+      puts "ERROR: Detected invalid AWS Lambda function names".color(:red)
+      puts <<~EOL
+        Lambda function names must start with a letter and can only contain letters, numbers, and underscores.
+        Invalid function names:
+
+        #{list}
+      EOL
+      exit 1
     end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes #520

## How to Test

Try to deploy with a method name that has a character that AWS Lambda does not support, like `def index!` , The exclamation mark `!` is not supported

Before:

    $ jets deploy
    ...
    Building CloudFormation templates.
    Generated CloudFormation templates at /tmp/jets/demo/templates
    Uploading CloudFormation templates to S3.
    Uploading code zip files to S3.
    Uploading /tmp/jets/demo/stage/zips/code-a67bb498.zip (14.5 KB) to S3
    Uploaded to s3://demo-dev-s3bucket-og2bk98m5k8s/jets/code/code-a67bb498.zip
    Time to upload code to s3: 0s
    Checking for modified public assets and uploading to S3.
    Time for public assets to s3: 0s
    Deploying CloudFormation stack with jets app!
    Waiting for stack to complete
    06:52:07PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack demo-dev User Initiated
    06:52:10PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack ApiGateway 
    06:52:10PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack JetsPreheatJob 
    06:52:11PM UPDATE_COMPLETE AWS::CloudFormation::Stack ApiGateway 
    06:52:12PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack ApiResources1 
    06:52:12PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack UpController 
    06:52:13PM UPDATE_FAILED AWS::CloudFormation::Stack UpController Template format error: Resource name Index!LambdaFunction is non alphanumeric.
    06:52:14PM UPDATE_FAILED AWS::CloudFormation::Stack ApiResources1 Resource update cancelled
    06:52:24PM UPDATE_FAILED AWS::CloudFormation::Stack JetsPreheatJob Resource update cancelled
    06:52:24PM UPDATE_ROLLBACK_IN_PROGRESS AWS::CloudFormation::Stack demo-dev The following resource(s) failed to update: [UpController, JetsPreheatJob, ApiResources1]. 
    06:52:27PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack ApiGateway 
    06:52:27PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack JetsPreheatJob 
    06:52:27PM UPDATE_COMPLETE AWS::CloudFormation::Stack ApiGateway 
    06:52:28PM UPDATE_IN_PROGRESS AWS::CloudFormation::Stack ApiResources1 
    06:52:38PM UPDATE_COMPLETE AWS::CloudFormation::Stack JetsPreheatJob 
    06:52:38PM UPDATE_COMPLETE AWS::CloudFormation::Stack ApiResources1 
    06:52:39PM UPDATE_COMPLETE AWS::CloudFormation::Stack UpController 
    06:52:40PM UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS AWS::CloudFormation::Stack demo-dev 
    06:52:41PM UPDATE_COMPLETE AWS::CloudFormation::Stack UpController 
    06:52:51PM UPDATE_COMPLETE AWS::CloudFormation::Stack ApiResources1 
    06:52:51PM UPDATE_COMPLETE AWS::CloudFormation::Stack JetsPreheatJob 
    06:52:52PM UPDATE_COMPLETE AWS::CloudFormation::Stack ApiGateway 
    06:52:52PM UPDATE_ROLLBACK_COMPLETE AWS::CloudFormation::Stack demo-dev 
    Stack rolled back: UPDATE_ROLLBACK_COMPLETE
    Time took: 46s
    The Jets application failed to deploy. Jets creates a few CloudFormation stacks to deploy your application.
    The logs above show the CloudFormation parent stack events and points to the stack with the error.
    Please go to the CloudFormation console and look for the specific stack with the error.
    The specific child stack usually shows more detailed information and can be used to resolve the issue.
    Example of checking the CloudFormation console: https://rubyonjets.com/docs/debugging/cloudformation/

After:

    $ jets deploy
    ....
    Building CloudFormation templates.
    ERROR: Detected invalid AWS Lambda function names
    Function names must start with a letter and can only contain letters, numbers, and underscores.
    Invalid function names detected:

        UpController#index!
## Version Changes

Patch