### PR TITLE
allow custom rake tasks with params to work with jets as well as rake command

### DIFF
--- a/lib/jets/cli.rb
+++ b/lib/jets/cli.rb
@@ -137,10 +137,16 @@ class Jets::CLI
     end
 
     return unless jets_project?
-    rake_task_found = Jets::Commands::RakeCommand.namespaced_commands.include?(full_command)
-    if rake_task_found
-      return Jets::Commands::RakeCommand
-    end
+
+    Jets::Commands::RakeCommand if rake_task_found
+  end
+
+  def rake_task_found
+    return false unless full_command # can be nil for subcommands and would break jets help without this check
+    bracket_regex = /\[.*/ # matches everything after the first [
+    command = full_command.sub(bracket_regex, '') # remove everything after the first [
+    namespaced_commands = Jets::Commands::RakeCommand.namespaced_commands.map {|x| x.sub(bracket_regex, '') }
+    namespaced_commands.include?(command)
   end
 
   def jets_project?


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes https://github.com/boltops-tools/jets/issues/484

## How to Test

lib/tasks/custom.rake

```ruby
namespace :custom do
  desc "Custom rake task with params."
  task :task, [:arg1, :arg2] => :environment do |t, args|
    puts "arg1: #{args[:arg1]}"
    puts "arg2: #{args[:arg2]}"
  end
end
```

Can run the custom task with params with jets now also.

    $ jets custom:task[0,'foo']
    arg1: 0
    arg2: foo

Before only worked with rake:

    $ rake custom:task[0,'foo']
    arg1: 0
    arg2: foo

The custom rake task also shows on up the help menu:

    $ jets -h
    ...
    Commands via rake:
      jets custom:task[arg1,arg2]  # Custom rake task with params
      jets db:create               # Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV ...
      jets db:drop                 # Drops the database from DATABASE_URL or con
## Version Changes

Patch