### PR TITLE
Validate lambda function names: fix regexp

### DIFF
--- a/lib/jets/cfn/builders/base_child_builder.rb
+++ b/lib/jets/cfn/builders/base_child_builder.rb
@@ -69,7 +69,7 @@ module Jets::Cfn::Builders
 
     def validate_function_names!
       invalids = @app_class.tasks.reject do |task|
-        task.meth =~ /^[a-zA-Z][a-zA-Z0-9_]$/
+        task.meth.to_s =~ /^[a-zA-Z][a-zA-Z0-9_]/
       end
       return if invalids.empty?
       list = invalids.map do |task|


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix validate function names regexp

## Context

Related https://github.com/boltops-tools/jets/pull/650

## Version Changes

Patch