### PR TITLE
refactor cleanup: rename Jets::Naming to Jets::Names

### DIFF
--- a/lib/jets/aws_info.rb
+++ b/lib/jets/aws_info.rb
@@ -73,7 +73,7 @@ module Jets
       return "fake-test-s3-bucket" if Jets.env.test?
       return @@s3_bucket unless @@s3_bucket == BUCKET_DOES_NOT_YET_EXIST
 
-      resp = cfn.describe_stacks(stack_name: Jets::Naming.parent_stack_name)
+      resp = cfn.describe_stacks(stack_name: Jets::Names.parent_stack_name)
       stack = resp.stacks.first
       output = stack["outputs"].find { |o| o["output_key"] == "S3Bucket" }
       @@s3_bucket = output["output_value"] # s3_bucket
@@ -83,7 +83,7 @@ module Jets
       # not been loaded in the config yet.  We do some trickery with loading
       # the config twice in Application#load_app_config
       # The first load will result in a Aws::CloudFormation::Errors::ValidationError
-      # since the Jets::Naming.parent_stack_name has not been properly set yet.
+      # since the Jets::Names.parent_stack_name has not been properly set yet.
       #
       # Rescuing all exceptions in case there are other exceptions dont know about yet
       # Here are the known ones: Aws::CloudFormation::Errors::ValidationError, Aws::CloudFormation::Errors::InvalidClientTokenId

--- a/lib/jets/cfn/builders/api_deployment_builder.rb
+++ b/lib/jets/cfn/builders/api_deployment_builder.rb
@@ -45,7 +45,7 @@ module Jets::Cfn::Builders
 
     # template_path is an interface method
     def template_path
-      Jets::Naming.api_deployment_template_path
+      Jets::Names.api_deployment_template_path
     end
 
     # do not bother writing a template if routes are empty

--- a/lib/jets/cfn/builders/api_gateway_builder.rb
+++ b/lib/jets/cfn/builders/api_gateway_builder.rb
@@ -18,7 +18,7 @@ module Jets::Cfn::Builders
 
     # template_path is an interface method
     def template_path
-      Jets::Naming.api_gateway_template_path
+      Jets::Names.api_gateway_template_path
     end
 
     # do not bother writing a template if routes are empty
@@ -101,7 +101,7 @@ module Jets::Cfn::Builders
 
     def api_gateway_physical_resource_id
       resp = cfn.describe_stack_resource(
-        stack_name: Jets::Naming.parent_stack_name,
+        stack_name: Jets::Names.parent_stack_name,
         logical_resource_id: "ApiGateway"
       )
       resp&.stack_resource_detail&.physical_resource_id

--- a/lib/jets/cfn/builders/api_resources_builder.rb
+++ b/lib/jets/cfn/builders/api_resources_builder.rb
@@ -16,7 +16,7 @@ module Jets::Cfn::Builders
 
     # template_path is an interface method
     def template_path
-      Jets::Naming.api_resources_template_path(@page)
+      Jets::Names.api_resources_template_path(@page)
     end
 
     def add_rest_api_parameter

--- a/lib/jets/cfn/builders/authorizer_builder.rb
+++ b/lib/jets/cfn/builders/authorizer_builder.rb
@@ -61,7 +61,7 @@ module Jets::Cfn::Builders
     end
 
     def template_path
-      Jets::Naming.authorizer_template_path(@path)
+      Jets::Names.authorizer_template_path(@path)
     end
   end
 end

--- a/lib/jets/cfn/builders/base_child_builder.rb
+++ b/lib/jets/cfn/builders/base_child_builder.rb
@@ -18,7 +18,7 @@ module Jets::Cfn::Builders
 
     # template_path is an interface method for Interface module
     def template_path
-      Jets::Naming.app_template_path(@app_class)
+      Jets::Names.app_template_path(@app_class)
     end
 
     def add_common_parameters

--- a/lib/jets/cfn/builders/parent_builder.rb
+++ b/lib/jets/cfn/builders/parent_builder.rb
@@ -19,7 +19,7 @@ module Jets::Cfn::Builders
 
     # template_path is an interface method
     def template_path
-      Jets::Naming.parent_template_path
+      Jets::Names.parent_template_path
     end
 
     def build_minimal_resources
@@ -90,7 +90,7 @@ module Jets::Cfn::Builders
     #    #{Jets.build_root}/templates/demo-dev-2-app-comments_controller.yml
     #    #{Jets.build_root}/templates/demo-dev-2-authorizers-main_authorizer.yml
     def for_each_path(type)
-      expression = "#{Jets::Naming.template_path_prefix}-#{type}-*"
+      expression = "#{Jets::Names.template_path_prefix}-#{type}-*"
       Dir.glob(expression).each do |path|
         next unless File.file?(path)
         yield(path)
@@ -123,7 +123,7 @@ module Jets::Cfn::Builders
     end
 
     def add_api_resources
-      expression = "#{Jets::Naming.template_path_prefix}-api-resources-*"
+      expression = "#{Jets::Names.template_path_prefix}-api-resources-*"
       # IE: path: #{Jets.build_root}/templates/demo-dev-2-api-resources-1.yml"
       Dir.glob(expression).sort.each do |path|
         next unless File.file?(path)

--- a/lib/jets/cfn/builders/shared_builder.rb
+++ b/lib/jets/cfn/builders/shared_builder.rb
@@ -8,7 +8,7 @@ module Jets::Cfn::Builders
 
     # template_path is an interface method for Interface module
     def template_path
-      Jets::Naming.shared_template_path(@app_class)
+      Jets::Names.shared_template_path(@app_class)
     end
   end
 end

--- a/lib/jets/cfn/ship.rb
+++ b/lib/jets/cfn/ship.rb
@@ -5,7 +5,7 @@ module Jets::Cfn
 
     def initialize(options)
       @options = options
-      @parent_stack_name = Jets::Naming.parent_stack_name
+      @parent_stack_name = Jets::Names.parent_stack_name
     end
 
     def run
@@ -81,7 +81,7 @@ module Jets::Cfn
     end
 
     def template
-      @template ||= TemplateSource.new(Jets::Naming.parent_template_path, @options)
+      @template ||= TemplateSource.new(Jets::Names.parent_template_path, @options)
     end
 
     # check for /(_COMPLETE|_FAILED)$/ status

--- a/lib/jets/cfn/status.rb
+++ b/lib/jets/cfn/status.rb
@@ -3,7 +3,7 @@ require 'cfn_status'
 module Jets::Cfn
   class Status < CfnStatus
     def initialize(options={})
-      @stack_name = Jets::Naming.parent_stack_name
+      @stack_name = Jets::Names.parent_stack_name
       super(@stack_name, options)
     end
   end

--- a/lib/jets/cfn/upload.rb
+++ b/lib/jets/cfn/upload.rb
@@ -21,7 +21,7 @@ module Jets::Cfn
 
     def upload_cfn_templates
       puts "Uploading CloudFormation templates to S3."
-      expression = "#{Jets::Naming.template_path_prefix}-*"
+      expression = "#{Jets::Names.template_path_prefix}-*"
       Dir.glob(expression).each do |path|
         next unless File.file?(path)
 

--- a/lib/jets/commands/call/base_guesser.rb
+++ b/lib/jets/commands/call/base_guesser.rb
@@ -56,7 +56,7 @@ class Jets::Commands::Call
 
     @@parent_stack = nil
     def parent_stack
-      @@parent_stack ||= cfn.describe_stacks(stack_name: Jets::Naming.parent_stack_name).stacks.first
+      @@parent_stack ||= cfn.describe_stacks(stack_name: Jets::Names.parent_stack_name).stacks.first
     end
   end
 end

--- a/lib/jets/commands/clean/log.rb
+++ b/lib/jets/commands/clean/log.rb
@@ -49,7 +49,7 @@ class Jets::Commands::Clean
 
   private
     def prefix_guess
-      Jets::Naming.parent_stack_name
+      Jets::Names.parent_stack_name
     end
 
     def log_groups

--- a/lib/jets/commands/delete.rb
+++ b/lib/jets/commands/delete.rb
@@ -90,7 +90,7 @@ class Jets::Commands::Delete
   end
 
   def parent_stack_name
-    Jets::Naming.parent_stack_name
+    Jets::Names.parent_stack_name
   end
 
   def are_you_sure?

--- a/lib/jets/commands/deploy.rb
+++ b/lib/jets/commands/deploy.rb
@@ -81,7 +81,7 @@ module Jets::Commands
     memoize :status
 
     def stack_name
-      Jets::Naming.parent_stack_name
+      Jets::Names.parent_stack_name
     end
 
     # Checks for a few things before deciding to delete the parent stack
@@ -117,7 +117,7 @@ module Jets::Commands
     def exit_unless_updateable!
       return if ENV['JETS_FORCE_UPDATEABLE'] # useful for debugging if stack stack updating
 
-      stack_name = Jets::Naming.parent_stack_name
+      stack_name = Jets::Names.parent_stack_name
       exists = stack_exists?(stack_name)
       return unless exists # continue because stack could be updating
 

--- a/lib/jets/commands/stack_info.rb
+++ b/lib/jets/commands/stack_info.rb
@@ -25,6 +25,6 @@ module Jets::Commands::StackInfo
   end
 
   def parent_stack_name
-    Jets::Naming.parent_stack_name
+    Jets::Names.parent_stack_name
   end
 end

--- a/lib/jets/commands/url.rb
+++ b/lib/jets/commands/url.rb
@@ -7,7 +7,7 @@ module Jets::Commands
     end
 
     def display
-      stack_name = Jets::Naming.parent_stack_name
+      stack_name = Jets::Names.parent_stack_name
       unless stack_exists?(stack_name)
         puts "Stack for #{Jets.config.project_name.color(:green)} project for environment #{Jets.env.color(:green)}.  Couldn't find #{stack_name.color(:green)} stack."
         exit

--- a/lib/jets/names.rb
+++ b/lib/jets/names.rb
@@ -1,7 +1,7 @@
-# This class groups the naming in one place.
-# Some naming is for CloudFormation
+# This class groups the names in one place.
+# Some names are for CloudFormation
 # Some are for the Build process
-class Jets::Naming
+class Jets::Names
   # Mainly used by build.rb
   class << self
     extend Memoist

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -91,7 +91,7 @@ module Jets
     #     ...
     #   ]
     def all_functions
-      parent_stack = cfn.describe_stack_resources(stack_name: Jets::Naming.parent_stack_name)
+      parent_stack = cfn.describe_stack_resources(stack_name: Jets::Names.parent_stack_name)
       parent_resources = parent_stack.stack_resources.select do |resource|
         resource.logical_resource_id =~ /Controller$/ # only controller functions
       end

--- a/lib/jets/resource/api_gateway/base_path/role.rb
+++ b/lib/jets/resource/api_gateway/base_path/role.rb
@@ -54,7 +54,7 @@ module Jets::Resource::ApiGateway::BasePath
 
     # Duplicated in rest_api/change_detection.rb, base_path/role.rb, rest_api/routes.rb
     def rest_api_id
-      stack_name = Jets::Naming.parent_stack_name
+      stack_name = Jets::Names.parent_stack_name
       return "RestApi" unless stack_exists?(stack_name)
 
       stack = cfn.describe_stacks(stack_name: stack_name).stacks.first

--- a/lib/jets/resource/api_gateway/deployment.rb
+++ b/lib/jets/resource/api_gateway/deployment.rb
@@ -33,7 +33,7 @@ module Jets::Resource::ApiGateway
     end
 
     def depends_on
-      expression = "#{Jets::Naming.template_path_prefix}-*_controller*"
+      expression = "#{Jets::Names.template_path_prefix}-*_controller*"
       controller_logical_ids = []
       Dir.glob(expression).each do |path|
         next unless File.file?(path)

--- a/lib/jets/resource/api_gateway/rest_api.rb
+++ b/lib/jets/resource/api_gateway/rest_api.rb
@@ -2,7 +2,7 @@ module Jets::Resource::ApiGateway
   class RestApi < Jets::Resource::Base
     def definition
       properties = {
-        name: Jets::Naming.gateway_api_name,
+        name: Jets::Names.gateway_api_name,
         endpoint_configuration: { types: endpoint_types }
       }
       properties[:endpoint_configuration][:vpc_endpoint_ids] = vpce_ids if vpce_ids

--- a/lib/jets/resource/api_gateway/rest_api/logical_id.rb
+++ b/lib/jets/resource/api_gateway/rest_api/logical_id.rb
@@ -88,7 +88,7 @@ class Jets::Resource::ApiGateway::RestApi
     end
 
     def parent_stack_name
-      Jets::Naming.parent_stack_name
+      Jets::Names.parent_stack_name
     end
 
     def default

--- a/lib/jets/resource/api_gateway/rest_api/routes/change.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change.rb
@@ -10,7 +10,7 @@ class Jets::Resource::ApiGateway::RestApi::Routes
     end
 
     def parent_stack_exists?
-      stack_exists?(Jets::Naming.parent_stack_name)
+      stack_exists?(Jets::Names.parent_stack_name)
     end
   end
 end

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -86,7 +86,7 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
 
     # Duplicated in rest_api/change_detection.rb, base_path/role.rb, rest_api/routes.rb
     def rest_api_id
-      stack_name = Jets::Naming.parent_stack_name
+      stack_name = Jets::Names.parent_stack_name
       return "RestApi" unless stack_exists?(stack_name)
 
       stack = cfn.describe_stacks(stack_name: stack_name).stacks.first

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/media_types.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/media_types.rb
@@ -30,7 +30,7 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     end
 
     def parent_stack_name
-      Jets::Naming.parent_stack_name
+      Jets::Names.parent_stack_name
     end
   end
 end

--- a/lib/jets/resource/api_gateway/rest_api/routes/change/page.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/page.rb
@@ -33,7 +33,7 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     # logical id to page map
     # Important: In Cfn::Builders::ApiGatewayBuilder, the add_gateway_routes and ApiResourcesBuilder needs to run
     # before the parent add_gateway_rest_api method.
-    def local_logical_ids_map(path_expression="#{Jets::Naming.template_path_prefix}-api-resources-*.yml")
+    def local_logical_ids_map(path_expression="#{Jets::Names.template_path_prefix}-api-resources-*.yml")
       logical_ids = {} # logical id => page number
 
       Dir.glob(path_expression).each do |path|
@@ -85,7 +85,7 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
     end
 
     def parent_resources
-      resp = cfn.describe_stack_resources(stack_name: Jets::Naming.parent_stack_name)
+      resp = cfn.describe_stack_resources(stack_name: Jets::Names.parent_stack_name)
       resp.stack_resources
     end
     memoize :parent_resources

--- a/lib/jets/resource/child_stack/api_deployment.rb
+++ b/lib/jets/resource/child_stack/api_deployment.rb
@@ -31,7 +31,7 @@ module Jets::Resource::ChildStack
     end
 
     def depends_on
-      expression = "#{Jets::Naming.template_path_prefix}-*_controller*"
+      expression = "#{Jets::Names.template_path_prefix}-*_controller*"
       controller_logical_ids = []
       Dir.glob(expression).each do |path|
         next unless File.file?(path)

--- a/lib/jets/resource/child_stack/api_resource.rb
+++ b/lib/jets/resource/child_stack/api_resource.rb
@@ -28,7 +28,7 @@ module Jets::Resource::ChildStack
       # Since dont have all the info required.
       # Read the template back to find the parameters required.
       # Actually might be easier to rationalize this approach.
-      template_path = Jets::Naming.api_resources_template_path(@page)
+      template_path = Jets::Names.api_resources_template_path(@page)
       template = Jets::Cfn::BuiltTemplate.get(template_path)
       template['Parameters'].keys.each do |p|
         case p

--- a/lib/jets/resource/child_stack/api_resource/page.rb
+++ b/lib/jets/resource/child_stack/api_resource/page.rb
@@ -3,7 +3,7 @@ class Jets::Resource::ChildStack::ApiResource
   # Returns: logical id of ApiResource Page
   class Page
     def self.logical_id(parameter)
-      expression = "#{Jets::Naming.template_path_prefix}-api-resources-*"
+      expression = "#{Jets::Names.template_path_prefix}-api-resources-*"
       # IE: path: #{Jets.build_root}/templates/demo-dev-2-api-resources-1.yml"
       template_paths = Dir.glob(expression).sort.to_a
       found_template = template_paths.detect do |path|

--- a/lib/jets/resource/child_stack/app_class.rb
+++ b/lib/jets/resource/child_stack/app_class.rb
@@ -125,7 +125,7 @@ module Jets::Resource::ChildStack
     end
 
     def current_app_class
-      templates_prefix = "#{Jets::Naming.template_path_prefix}-app-"
+      templates_prefix = "#{Jets::Names.template_path_prefix}-app-"
       @path.sub(templates_prefix, '')
         .sub(/\.yml$/,'')
         .gsub('-','/')

--- a/lib/jets/resource/child_stack/shared.rb
+++ b/lib/jets/resource/child_stack/shared.rb
@@ -63,7 +63,7 @@ module Jets::Resource::ChildStack
     # IE: app/resource.rb => Resource
     # Returns Resource class object in the example
     def current_shared_class
-      templates_prefix = "#{Jets::Naming.template_path_prefix}-shared-"
+      templates_prefix = "#{Jets::Names.template_path_prefix}-shared-"
       @path.sub(templates_prefix, '')
         .sub(/\.yml$/,'')
         .gsub('-','/')

--- a/spec/lib/jets/names_spec.rb
+++ b/spec/lib/jets/names_spec.rb
@@ -1,0 +1,6 @@
+describe Jets::Names do
+  it "provides some names used throughout jets" do
+    names = Jets::Names
+    expect(names.parent_stack_name).to eq "demo-test"
+  end
+end

--- a/spec/lib/jets/naming_spec.rb
+++ b/spec/lib/jets/naming_spec.rb
@@ -1,6 +1,0 @@
-describe Jets::Naming do
-  it "provides some names used throughout jets" do
-    naming = Jets::Naming
-    expect(naming.parent_stack_name).to eq "demo-test"
-  end
-end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Just some refactoring cleanup.  Rename `Jets::Naming` to `Jets::Names`

## Version Changes

Patch