### PR TITLE
fix cors when using authorizers

### DIFF
--- a/lib/jets/resource/api_gateway/cors.rb
+++ b/lib/jets/resource/api_gateway/cors.rb
@@ -51,7 +51,7 @@ module Jets::Resource::ApiGateway
     end
 
     def cors_authorization_type
-      Jets.config.api.cors_authorization_type || @route.authorization_type || "NONE"
+      Jets.config.api.cors_authorization_type || "NONE"
     end
 
     def cors_logical_id


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes cors when authorizers also used. 

Simply removed the `@route.authorization_type` in the or assignment.

Cannot think of a case where we also want cors OPTIONS requests to also have to go through the authorizer.

## Context

Fixes #465

## How to Test

Deploy app that has both cors enabled and uses an authorizer.

* https://rubyonjets.com/docs/cors-support/
* https://rubyonjets.com/docs/routing/authorizers/


## Version Changes

Patch