### PR TITLE
fix prewarming iam permission

### DIFF
--- a/lib/jets/internal/app/jobs/jets/preheat_job.rb
+++ b/lib/jets/internal/app/jobs/jets/preheat_job.rb
@@ -17,11 +17,11 @@ class Jets::PreheatJob < ApplicationJob
       ]
     },
     {
-      sid: "Statement2",
-      action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
-      effect: "Allow",
-      resource: [
-        sub("arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${WarmLambdaFunction}")
+      Sid: "Statement2",
+      Action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
+      Effect: "Allow",
+      Resource: [
+        sub("arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:#{Jets.project_namespace}-*")
       ]
     }
   )

--- a/lib/jets/lambda/dsl.rb
+++ b/lib/jets/lambda/dsl.rb
@@ -234,11 +234,13 @@ module Jets::Lambda::Dsl
       end
 
       def ref(name)
-        "!Ref #{name.to_s.camelize}"
+        name = name.is_a?(Symbol) ? name.to_s.camelize : name
+        "!Ref #{name}"
       end
 
       def sub(value)
-        "!Sub #{value.to_s.camelize}"
+        value = value.is_a?(Symbol) ? value.to_s.camelize : value
+        "!Sub #{value}"
       end
 
       # meth is a Symbol


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix prewarming IAM Permission

## Context

Related https://github.com/boltops-tools/jets/pull/645

## How to Test

1. Deploy jets demo app
2. Use `jets console` to call lambda function: `Jets::PreheatJob.perform_now(:warm)`
3. Confirm by checking the CloudWatch logs on the demo-dev-jets-preheat_job-warm

## Version Changes

Patch