### PR TITLE
Fix prewarming

### DIFF
--- a/lib/jets/commands/call.rb
+++ b/lib/jets/commands/call.rb
@@ -17,7 +17,9 @@ class Jets::Commands::Call
   end
 
   def function_name
-    if @guess
+    if @provided_function_name.starts_with?(Jets.config.project_namespace)
+      @provided_function_name # fully qualified function name
+    elsif @guess      
       ensure_guesses_found! # possibly exits here
       guesser.function_name # guesser adds namespace already
     else

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -1,6 +1,7 @@
 module Jets
   class Preheat
     extend Memoist
+    include Jets::AwsServices
 
     # Examples:
     #

--- a/lib/jets/preheat.rb
+++ b/lib/jets/preheat.rb
@@ -102,7 +102,9 @@ module Jets
         stack_resources.each do |stack_resource|
           acc << stack_resource if stack_resource.logical_resource_id.ends_with?('LambdaFunction') # only functions
         end
-      end.flatten.uniq.compact
+        acc
+      end
+      resources.map(&:physical_resource_id) # function names
     end
     memoize :all_functions
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix prewarming, when `config.prewarm.concurrency = 1`

Note: Think may simplify prewarm config options in the next major release of Jets v5.

## Context

Fixes #659

## How to Test

config/application.rb

```ruby
Jets.application.configure do
  # ...
  config.prewarm.concurrency = 1
end

## Version Changes

Patch