### PR TITLE
fix vpc iam permissions

### DIFF
--- a/lib/jets/application/defaults.rb
+++ b/lib/jets/application/defaults.rb
@@ -2,8 +2,8 @@ class Jets::Application
   module Defaults
     extend ActiveSupport::Concern
 
-    included do
-      def self.default_iam_policy
+    class_methods do
+      def default_iam_policy
         project_namespace = Jets.project_namespace
         logs = {
           action: ["logs:*"],
@@ -24,23 +24,22 @@ class Jets::Application
         }
         policies << cloudformation
 
-        if Jets.config.function.vpc_config
-          vpc = {
-            action: %w[
-              ec2:CreateNetworkInterface
-              ec2:DeleteNetworkInterface
-              ec2:DescribeNetworkInterfaces
-              ec2:DescribeVpcs
-              ec2:DescribeSubnets
-              ec2:DescribeSecurityGroups
-            ],
-            effect: "Allow",
-            resource: "*",
-          }
-          policies << vpc
-        end
-
         policies
+      end
+
+      def vpc_iam_policy_statement
+        {
+          Action: %w[
+            ec2:CreateNetworkInterface
+            ec2:DeleteNetworkInterface
+            ec2:DescribeNetworkInterfaces
+            ec2:DescribeVpcs
+            ec2:DescribeSubnets
+            ec2:DescribeSecurityGroups
+          ],
+          Effect: "Allow",
+          Resource: "*",
+        }
       end
     end
 
@@ -200,6 +199,30 @@ class Jets::Application
         app/functions
         app/shared/functions
       ]
+    end
+
+    # Used by app/jobs/jets/preheat_job.rb
+    def preheat_job_iam_policy
+      policy = [
+        {
+          Sid: "Statement1",
+          Action: ["logs:*"],
+          Effect: "Allow",
+          Resource: [{
+            "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${JetsPreheatJobWarmLambdaFunction}"
+          }]
+        },
+        {
+          Sid: "Statement2",
+          Action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
+          Effect: "Allow",
+          Resource: [{
+            "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:#{Jets.project_namespace}-*"
+          }]
+        }
+      ]
+      policy << Jets::Application.vpc_iam_policy_statement if Jets.config.function.vpc_config
+      policy
     end
   end
 end

--- a/lib/jets/internal/app/jobs/jets/preheat_job.rb
+++ b/lib/jets/internal/app/jobs/jets/preheat_job.rb
@@ -7,24 +7,7 @@ class Jets::PreheatJob < ApplicationJob
 
   class_timeout 30
   class_memory 1024
-  class_iam_policy(
-    {
-      sid: "Statement1",
-      action: ["logs:*"],
-      effect: "Allow",
-      resource: [
-        sub("arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${WarmLambdaFunction}"),
-      ]
-    },
-    {
-      Sid: "Statement2",
-      Action: ["lambda:InvokeFunction", "lambda:InvokeAsync"],
-      Effect: "Allow",
-      Resource: [
-        sub("arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:#{Jets.project_namespace}-*")
-      ]
-    }
-  )
+  class_iam_policy(Jets.config.preheat_job_iam_policy)
 
   rate(PREWARM_RATE) if torching
   def torch

--- a/lib/jets/resource/iam/base_role_definition.rb
+++ b/lib/jets/resource/iam/base_role_definition.rb
@@ -24,11 +24,25 @@ module Jets::Resource::Iam
         }
       }
 
+      # Add vpc permissions to all policies
+      definition[logical_id][:properties][:policies] = [
+        policy_name: "vpc", # required, limited to 128-chars
+        policy_document: vpc_policy_document,
+      ] if vpc_policy_document
+
       unless managed_policy_arns.empty?
         definition[logical_id][:properties][:managed_policy_arns] = managed_policy_arns
       end
 
       definition
+    end
+
+    def vpc_policy_document
+      if Jets.config.function.vpc_config
+        {
+          Statement: [Jets::Application.vpc_iam_policy_statement]
+        }
+      end
     end
 
     def policy_document


### PR DESCRIPTION
This is a 🐞 bug fix
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* Add VPC policy permission to IAM role as inline policy
* Makes the IAM permission available everywhere immediately and avoids the race condition when creating lambda functions.
* Also add VPC IAM permission to jets preheat job.

## Context

Fixes #661

## How to Test

Deploy with VPC. See Docs: https://rubyonjets.com/docs/considerations/vpc/

## Version Changes

Patch