### PR TITLE
Jeremiah-Parrack | only add add_stage_name when request is present

### DIFF
--- a/lib/jets/overrides/rails/common_methods.rb
+++ b/lib/jets/overrides/rails/common_methods.rb
@@ -2,7 +2,7 @@ module Jets::CommonMethods
   extend Memoist
   # Add API Gateway Stage Name
   def add_stage_name(url)
-    Jets::Controller::Stage.add(request.host, url)
+    Jets::Controller::Stage.add(request.host, url) if request.present?
   end
 
   def on_aws?


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://rubyonjets.com/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
When sending mail locally add_stage_name gets called but is nill. So only add stage name when request is present, this way mail is sent locally. 

<!--
Provide a description of what your pull request changes.
-->

## Context
https://github.com/boltops-tools/jets/issues/664
<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Jets project, please provide an example repo.
-->


## Version Changes
patch
4.0.5
<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

