### PR TITLE
Add optional command args to the jets runner command.

### DIFF
--- a/lib/jets/commands/help/runner.md
+++ b/lib/jets/commands/help/runner.md
@@ -15,3 +15,26 @@ puts "hello world: #{Jets.env}"
 
     $ jets runner file://script.rb
     hello world: development
+
+
+Optionally pass in an argument on the command line:
+
+    Usage: jets runner file|Ruby code [args]
+
+The argument will be assigned to the `args` variable.
+
+Example:
+
+    $ jets runner 'puts "hello world with args: #{args}"' 123
+    hello world with args: 123
+
+
+Example with script.rb:
+
+```ruby
+puts "hello world with args: #{args}"
+```
+
+    $ jets runner file://script.rb 123
+    hello world with args: 123
+

--- a/lib/jets/commands/main.rb
+++ b/lib/jets/commands/main.rb
@@ -72,8 +72,8 @@ module Jets::Commands
 
     desc "runner", "Run Ruby code in the context of Jets app non-interactively"
     long_desc Help.text(:runner)
-    def runner(code)
-      Runner.run(code)
+    def runner(code, args=nil)
+      Runner.run(code, args)
     end
 
     desc "dbconsole", "Starts DB REPL console"

--- a/lib/jets/commands/runner.rb
+++ b/lib/jets/commands/runner.rb
@@ -1,5 +1,5 @@
 class Jets::Commands::Runner
-  def self.run(code)
+  def self.run(code, args=nil)
     if code =~ %r{^file://}
       path = code.sub('file://', '')
       full_path = "#{Jets.root}/#{path}"


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

I'm using the `jets runner` for various maintenance tasks (eg create or update data) and it would be very handy to be able to pass in cli args.

## Context

No

## How to Test

I didn't see jets runner tests. I've simply tested in on the cli, with inline Ruby and a test script.

## Version Changes

No opinion about version.

Thanks for considering!