### PR TITLE
Fixes IAM role permissions for PreheatJob

### DIFF
--- a/lib/jets/internal/app/jobs/jets/preheat_job.rb
+++ b/lib/jets/internal/app/jobs/jets/preheat_job.rb
@@ -7,7 +7,7 @@ class Jets::PreheatJob < ApplicationJob
 
   class_timeout 30
   class_memory 1024
-  class_iam_policy(Jets.config.preheat_job_iam_policy)
+  class_iam_policy(Jets::Application.preheat_job_iam_policy)
 
   rate(PREWARM_RATE) if torching
   def torch

--- a/spec/lib/jets/internal/preheat_job_spec.rb
+++ b/spec/lib/jets/internal/preheat_job_spec.rb
@@ -3,6 +3,14 @@ describe Jets::PreheatJob do
     Jets::PreheatJob.new({},{},nil)
   end
 
+  context "IAM policy" do
+    it "has a class_iam_policy with lambda::InvokeFunction" do
+      expect(Jets::PreheatJob.class_iam_policy).to include(hash_including(
+        :Action=>["lambda:InvokeFunction", "lambda:InvokeAsync"]
+      ))
+    end
+  end
+
   context "warm" do
     it "calls all lambda functions with a prewarm request" do
       allow(Jets::Preheat).to receive(:warm_all)


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes the default IAM policy for Jets::PreheatJob

## Context

The IAM role for PreheatJob appears to have been broken in c36f87f15e42c91991a867c2b6b10d4054b0603e, resulting in errors on Lambda like this:

> Aws::Lambda::Errors::AccessDeniedException User: arn:aws:sts::652695076726:assumed-role/bot-dev-JetsPreheatJob-1OYM89-JetsPreheatJobIamRole-C7QgfgQgszTl/bot-dev-jets-preheat_job-warm is not authorized to perform: lambda:InvokeFunction on resource: arn:aws:lambda:us-east-1:652695076726:function:bot-dev-admin_controller-db because no identity-based policy allows the lambda:InvokeFunction action

Basically, the generated `app-name-preheat-job-policy` was missing permission to invoke Lambda functions.

## How to Test

View the generated policy document in the Lambda console for the execution role associated with the preheat_job-warm function, and verify that it includes lambda:InvokeFunction.


## Version Changes

patch version bump to 4.0.6

