### PR TITLE
pin dynomite 1.2.7

### DIFF
--- a/lib/jets/commands/templates/skeleton/Gemfile.tt
+++ b/lib/jets/commands/templates/skeleton/Gemfile.tt
@@ -16,7 +16,7 @@ gem "pg", "~> 1.2.3"
 gem "mysql2", "~> 0.5.3"
 <% end %>
 <% unless options[:mode] == 'job' -%>
-gem "dynomite"
+gem "dynomite", "~> 1.2.7"
 <% end -%>
 gem "zeitwerk", ">= 2.5.0"
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The new dynomite 2.0.0 requires jets v5. This pins dynomite to 1.2.7 so `jets new` with people using jets v4 will still work.

## How to Test

    jets version
    jets new demo # make sure this works

## Version Changes

Patch