### PR TITLE
handle option method or http_method from route state

### DIFF
--- a/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
+++ b/lib/jets/resource/api_gateway/rest_api/routes/change/base.rb
@@ -14,9 +14,10 @@ class Jets::Resource::ApiGateway::RestApi::Routes::Change
       return [] if data.nil?
 
       data.map do |item|
+        method = item.dig('options','method') || item.dig('options','http_method')
         Jets::Router::Route.new(
           path: item['path'],
-          method: item['options']['method'],
+          method: method,
           to: item['to'],
         )
       end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow the route change detection to handle either `http_method` or `method` from the route state file.

## Version Changes

Patch